### PR TITLE
fix: rename delta_profit to cumulative_profit

### DIFF
--- a/apps/predict-ui/src/components/ProfitOverTime/ProfitOverTime.tsx
+++ b/apps/predict-ui/src/components/ProfitOverTime/ProfitOverTime.tsx
@@ -51,7 +51,7 @@ export const ProfitOverTime = () => {
     if (!data || data.points.length === 0) return [];
     return data.points.map((point) => ({
       timestamp: new Date(point.timestamp),
-      value: point.delta_profit,
+      value: point.cumulative_profit,
     }));
   }, [data]);
 

--- a/apps/predict-ui/src/mocks/mockProfitOverTime.ts
+++ b/apps/predict-ui/src/mocks/mockProfitOverTime.ts
@@ -1,14 +1,26 @@
 import { AgentProfitTimeseriesResponse, AgentWindow } from '../types';
 
-const getRandomCumulativeProfit = (numberOfPoints: number) =>
-  Array.from({ length: numberOfPoints }, (_, i) => {
+const getRandomCumulativeProfit = (numberOfPoints: number) => {
+  const points: { timestamp: string; cumulative_profit: number }[] = [];
+  let cumulative = 0;
+  for (let i = 0; i < numberOfPoints; i++) {
     const date = new Date();
     date.setDate(date.getDate() - (numberOfPoints - 1 - i));
-    return {
+    if (i === 0) {
+      // Ensure the series begins at $0 as per UI copy
+      cumulative = 0;
+    } else {
+      // Generate a random profit/loss delta and accumulate it
+      const delta = parseFloat(((Math.random() - 0.5) * 10).toFixed(2)); // range approx [-5, 5]
+      cumulative = parseFloat((cumulative + delta).toFixed(2));
+    }
+    points.push({
       timestamp: date.toISOString(),
-      cumulative_profit: parseFloat((Math.random() * 100 - 2).toFixed(2)),
-    };
-  });
+      cumulative_profit: cumulative,
+    });
+  }
+  return points;
+};
 
 export const getMockProfitOverTime = (window: AgentWindow): AgentProfitTimeseriesResponse => {
   if (window === '90d') {

--- a/apps/predict-ui/src/mocks/mockProfitOverTime.ts
+++ b/apps/predict-ui/src/mocks/mockProfitOverTime.ts
@@ -1,12 +1,12 @@
 import { AgentProfitTimeseriesResponse, AgentWindow } from '../types';
 
-const getRandomDeltaProfit = (numberOfPoints: number) =>
+const getRandomCumulativeProfit = (numberOfPoints: number) =>
   Array.from({ length: numberOfPoints }, (_, i) => {
     const date = new Date();
     date.setDate(date.getDate() - (numberOfPoints - 1 - i));
     return {
       timestamp: date.toISOString(),
-      delta_profit: parseFloat((Math.random() * 100 - 2).toFixed(2)),
+      cumulative_profit: parseFloat((Math.random() * 100 - 2).toFixed(2)),
     };
   });
 
@@ -16,7 +16,7 @@ export const getMockProfitOverTime = (window: AgentWindow): AgentProfitTimeserie
       agent_id: 'agent_123',
       currency: 'USD',
       window: '90d',
-      points: getRandomDeltaProfit(90),
+      points: getRandomCumulativeProfit(90),
     };
   }
 
@@ -25,7 +25,7 @@ export const getMockProfitOverTime = (window: AgentWindow): AgentProfitTimeserie
       agent_id: 'agent_123',
       currency: 'USD',
       window: '30d',
-      points: getRandomDeltaProfit(30),
+      points: getRandomCumulativeProfit(30),
     };
   }
 
@@ -34,13 +34,13 @@ export const getMockProfitOverTime = (window: AgentWindow): AgentProfitTimeserie
     currency: 'USD',
     window: '7d',
     points: [
-      { timestamp: '2025-07-18T00:00:00Z', delta_profit: 0.3 },
-      { timestamp: '2025-07-19T00:00:00Z', delta_profit: 0 },
-      { timestamp: '2025-07-19T12:00:00Z', delta_profit: -2.5 },
-      { timestamp: '2025-07-20T00:00:00Z', delta_profit: 1.2 },
-      { timestamp: '2025-07-21T00:00:00Z', delta_profit: 0.4 },
-      { timestamp: '2025-07-22T00:00:00Z', delta_profit: 3.0 },
-      { timestamp: '2025-07-25T00:00:00Z', delta_profit: 0.5 },
+      { timestamp: '2025-07-18T00:00:00Z', cumulative_profit: 0.3 },
+      { timestamp: '2025-07-19T00:00:00Z', cumulative_profit: 0 },
+      { timestamp: '2025-07-19T12:00:00Z', cumulative_profit: -2.5 },
+      { timestamp: '2025-07-20T00:00:00Z', cumulative_profit: 1.2 },
+      { timestamp: '2025-07-21T00:00:00Z', cumulative_profit: 0.4 },
+      { timestamp: '2025-07-22T00:00:00Z', cumulative_profit: 3.0 },
+      { timestamp: '2025-07-25T00:00:00Z', cumulative_profit: 0.5 },
     ],
   };
 };

--- a/apps/predict-ui/src/types.ts
+++ b/apps/predict-ui/src/types.ts
@@ -119,6 +119,11 @@ export type PositionDetails = {
 export type AgentProfitPoint = {
   /** ISO 8601 timestamp */
   timestamp: string;
+  /**
+   * Window-relative cumulative PnL at this timestamp.
+   * Starts at 0 at the beginning of the selected window, may go negative.
+   * Units: same `currency` as the surrounding timeseries response.
+   */
   cumulative_profit: number;
 };
 

--- a/apps/predict-ui/src/types.ts
+++ b/apps/predict-ui/src/types.ts
@@ -119,7 +119,7 @@ export type PositionDetails = {
 export type AgentProfitPoint = {
   /** ISO 8601 timestamp */
   timestamp: string;
-  delta_profit: number;
+  cumulative_profit: number;
 };
 
 export type AgentProfitTimeseriesResponse = {


### PR DESCRIPTION
## Summary
- Renames `delta_profit` field to `cumulative_profit` in the profit-over-time chart to match the backend API change
- The value is window-relative cumulative PnL, not a daily delta — the old name was misleading

## Files changed
- `types.ts` — `AgentProfitPoint.delta_profit` → `cumulative_profit`
- `ProfitOverTime.tsx` — field access updated
- `mockProfitOverTime.ts` — mock data updated

## Paired with
Backend change in valory-xyz/trader (branch `jenslee/predict-825-fix-roi-audit-issues`) — audit issue M-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)