### PR TITLE
feat(OPE-1603): add metrics outdated banner for polystrat

### DIFF
--- a/apps/predict-ui/__tests__/app/agent.polystrat.spec.tsx
+++ b/apps/predict-ui/__tests__/app/agent.polystrat.spec.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+
+import { Agent } from '../../src/app/agent';
+import { useAgentDetails } from '../../src/hooks/useAgentDetails';
+import { useFeatures } from '../../src/hooks/useFeatures';
+
+jest.mock('../../src/utils/agentMap', () => ({
+  agentType: 'polystrat_trader',
+  isOmenstratAgent: false,
+  isPolystratAgent: true,
+}));
+jest.mock('../../src/hooks/useAgentDetails');
+jest.mock('../../src/hooks/useFeatures');
+jest.mock('../../src/components/Chat/Chat', () => ({
+  Chat: () => <div data-testid="chat-mock">Chat</div>,
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+const mockAgentDetails = {
+  id: '0xabc',
+  created_at: '2024-01-01T00:00:00Z',
+  last_active_at: '2024-06-01T00:00:00Z',
+};
+
+const mockPerformance = {
+  agent_id: '0xabc',
+  window: 'lifetime',
+  currency: 'USD',
+  metrics: {
+    all_time_funds_used: 20,
+    all_time_profit: 2,
+    funds_locked_in_markets: 0.1,
+    available_funds: 10,
+    roi: 0.1,
+  },
+  stats: { predictions_made: 100, prediction_accuracy: 0.5 },
+};
+
+describe('Agent (polystrat)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFeatures as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: { isChatEnabled: false },
+    });
+  });
+
+  it('renders the metrics outdated banner', () => {
+    (useAgentDetails as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { agentDetails: mockAgentDetails, performance: mockPerformance },
+    });
+    render(<Agent />, { wrapper: createWrapper() });
+    expect(
+      screen.getByText(/Performance and activity stats are temporarily not updating/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Last updated/)).toBeInTheDocument();
+  });
+});

--- a/apps/predict-ui/__tests__/app/agent.spec.tsx
+++ b/apps/predict-ui/__tests__/app/agent.spec.tsx
@@ -89,6 +89,18 @@ describe('Agent', () => {
     expect(screen.getByText('Performance')).toBeInTheDocument();
   });
 
+  it('does not render the polystrat metrics banner when agent is omenstrat', () => {
+    (useAgentDetails as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { agentDetails: mockAgentDetails, performance: mockPerformance },
+    });
+    render(<Agent />, { wrapper: createWrapper() });
+    expect(
+      screen.queryByText(/Performance and activity stats are temporarily not updating/),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders UnlockChat when isChatEnabled=false and features loaded', () => {
     (useAgentDetails as jest.Mock).mockReturnValue({
       isLoading: false,

--- a/apps/predict-ui/__tests__/components/MetricsOutdatedBanner.spec.tsx
+++ b/apps/predict-ui/__tests__/components/MetricsOutdatedBanner.spec.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+
+import { MetricsOutdatedBanner } from '../../src/components/MetricsOutdatedBanner';
+
+describe('MetricsOutdatedBanner', () => {
+  it('renders the last updated timestamp', () => {
+    render(<MetricsOutdatedBanner />);
+    expect(screen.getByText(/Last updated/)).toBeInTheDocument();
+  });
+
+  it('renders the protocol upgrade description', () => {
+    render(<MetricsOutdatedBanner />);
+    expect(
+      screen.getByText(
+        'Performance and activity stats are temporarily not updating after a recent Polymarket protocol upgrade. Your agent works as usual.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/predict-ui/__tests__/components/ui/Alert.spec.tsx
+++ b/apps/predict-ui/__tests__/components/ui/Alert.spec.tsx
@@ -21,6 +21,10 @@ describe('Alert', () => {
     expect(() => render(<Alert type="warning" message="Warning" />)).not.toThrow();
   });
 
+  it('renders without crashing for type="info"', () => {
+    expect(() => render(<Alert type="info" message="Info" />)).not.toThrow();
+  });
+
   it('renders with ReactNode message', () => {
     const { getByText } = render(<Alert type="error" message={<span>Custom node</span>} />);
     expect(getByText('Custom node')).toBeInTheDocument();

--- a/apps/predict-ui/src/app/agent.tsx
+++ b/apps/predict-ui/src/app/agent.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { AgentDetails } from '../components/AgentDetails';
 import { Chat } from '../components/Chat/Chat';
 import { ErrorState } from '../components/ErrorState';
+import { MetricsOutdatedBanner } from '../components/MetricsOutdatedBanner';
 import { AgentPerformance } from '../components/Performance';
 import { ProfitOverTime } from '../components/ProfitOverTime/ProfitOverTime';
 import { Strategy } from '../components/Strategy';
@@ -14,6 +15,7 @@ import { Card } from '../components/ui/Card';
 import { COLOR } from '../constants/theme';
 import { useAgentDetails } from '../hooks/useAgentDetails';
 import { useFeatures } from '../hooks/useFeatures';
+import { isPolystratAgent } from '../utils/agentMap';
 
 const AgentContent = styled.div`
   display: flex;
@@ -108,6 +110,7 @@ export const Agent = () => {
           createdAt={agentDetails.created_at}
           lastActiveAt={agentDetails.last_active_at}
         />
+        {isPolystratAgent && <MetricsOutdatedBanner />}
         <AgentPerformance performance={performance} />
         <ProfitOverTime />
         <TradeHistory />

--- a/apps/predict-ui/src/components/MetricsOutdatedBanner.tsx
+++ b/apps/predict-ui/src/components/MetricsOutdatedBanner.tsx
@@ -1,0 +1,20 @@
+import { Alert } from './ui/Alert';
+
+const METRICS_LAST_UPDATED_AT = new Date('2026-04-28T11:00:00Z');
+
+const DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  hour12: true,
+};
+
+export const MetricsOutdatedBanner = () => (
+  <Alert
+    type="info"
+    message={`Last updated ${METRICS_LAST_UPDATED_AT.toLocaleString('en-US', DATE_FORMAT)}`}
+    description="Performance and activity stats are temporarily not updating after a recent Polymarket protocol upgrade. Your agent works as usual."
+  />
+);

--- a/apps/predict-ui/src/components/ui/Alert.tsx
+++ b/apps/predict-ui/src/components/ui/Alert.tsx
@@ -1,11 +1,11 @@
-import { WarningOutlined } from '@ant-design/icons';
+import { InfoCircleOutlined, WarningOutlined } from '@ant-design/icons';
 import { Alert as AntdAlert, Flex } from 'antd';
 import { CSSProperties, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { COLOR } from '../../constants/theme';
 
-type AlertType = 'warning' | 'error';
+type AlertType = 'warning' | 'error' | 'info';
 
 type AlertProps = {
   type: AlertType;
@@ -14,15 +14,24 @@ type AlertProps = {
   style?: CSSProperties;
 };
 
+const ALERT_STYLES: Record<AlertType, { bg: string; border: string; color: string }> = {
+  warning: { bg: COLOR.YELLOW_BACKGROUND, border: COLOR.YELLOW_BACKGROUND, color: COLOR.YELLOW },
+  error: { bg: COLOR.RED_BACKGROUND, border: COLOR.RED_BACKGROUND, color: COLOR.RED },
+  info: { bg: COLOR.INFO_BACKGROUND, border: COLOR.INFO_BORDER, color: COLOR.INFO },
+};
+
 const StyledAlert = styled(AntdAlert)<{ $alertType: AlertType }>`
   padding: 12px;
   align-items: flex-start;
-  background: ${(props) =>
-    props.$alertType === 'warning' ? COLOR.YELLOW_BACKGROUND : COLOR.RED_BACKGROUND};
-  border-color: ${(props) =>
-    props.$alertType === 'warning' ? COLOR.YELLOW_BACKGROUND : COLOR.RED_BACKGROUND};
-  color: ${(props) => (props.$alertType === 'warning' ? COLOR.YELLOW : COLOR.RED)};
+  background: ${(props) => ALERT_STYLES[props.$alertType].bg};
+  border-color: ${(props) => ALERT_STYLES[props.$alertType].border};
+  color: ${(props) => ALERT_STYLES[props.$alertType].color};
 `;
+
+const ALERT_ICONS: Partial<Record<AlertType, ReactNode>> = {
+  warning: <WarningOutlined style={{ fontSize: 18, marginTop: '2px', color: COLOR.YELLOW }} />,
+  info: <InfoCircleOutlined style={{ fontSize: 18, marginTop: '2px', color: COLOR.INFO }} />,
+};
 
 export const Alert = ({ type, message, description, style }: AlertProps) => {
   return (
@@ -36,11 +45,7 @@ export const Alert = ({ type, message, description, style }: AlertProps) => {
       }
       type={type}
       showIcon
-      icon={
-        type === 'warning' ? (
-          <WarningOutlined style={{ fontSize: 18, marginTop: '2px', color: COLOR.YELLOW }} />
-        ) : undefined
-      }
+      icon={ALERT_ICONS[type]}
       style={{ ...style }}
     />
   );

--- a/apps/predict-ui/src/constants/theme.ts
+++ b/apps/predict-ui/src/constants/theme.ts
@@ -58,6 +58,10 @@ export const COLOR = {
 
   BLUE: '#1677FF',
   LIGHT_GRAY: '#F8F9FA',
+
+  INFO: '#1AA0FF',
+  INFO_BACKGROUND: 'rgba(26, 160, 255, 0.1)',
+  INFO_BORDER: 'rgba(26, 160, 255, 0.2)',
 };
 
 export const THEME_CONFIG: ThemeConfig = {


### PR DESCRIPTION
## Summary
- Adds an info banner on the polystrat agent page stating that performance and activity stats are temporarily not updating following the Polymarket v2 protocol upgrade (per [OPE-1603](https://linear.app/valory-xyz/issue/OPE-1603)).
- Banner renders between the AgentDetails card and the Performance card, and is gated on `isPolystratAgent` (hidden for omenstrat).
- Matches the Figma design: https://www.figma.com/design/HB1eVqbkaFRYs6NXbUmuQM/Pearl-1.0?node-id=21684-114726
- Extends the shared `Alert` component with an `info` variant + adds `INFO` color tokens to the theme.

## Known follow-up
- **"Last updated" timestamp is currently hardcoded** (`2026-04-28T11:00:00Z`) in `MetricsOutdatedBanner.tsx`. This needs to come from the agent side — keeping this PR in draft until the backend exposes the last-successful-sync timestamp, at which point we'll wire it through `useAgentDetails` (or equivalent).

## Test plan
- [x] `yarn nx lint predict-ui` passes
- [x] `yarn nx test predict-ui` passes (210 tests, new + modified files at 100% coverage)
- [ ] Visually verify banner renders for `REACT_APP_AGENT_NAME=polystrat_trader`
- [ ] Visually verify banner does NOT render for `REACT_APP_AGENT_NAME=omenstrat_trader`

🤖 Generated with [Claude Code](https://claude.com/claude-code)