### PR TITLE
feat: add withdraw locked funds card for polystrat

### DIFF
--- a/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
+++ b/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
@@ -1,0 +1,260 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { WithdrawLockedFunds } from '../../../src/components/WithdrawLockedFunds';
+import { useWithdrawLockedFunds } from '../../../src/hooks/useWithdrawLockedFunds';
+
+jest.mock('../../../src/hooks/useWithdrawLockedFunds');
+
+const mockedHook = useWithdrawLockedFunds as jest.Mock;
+
+const renderCard = (props?: Partial<React.ComponentProps<typeof WithdrawLockedFunds>>) =>
+  render(<WithdrawLockedFunds lockedAmount={120.32} marketName="Polymarket" {...(props ?? {})} />);
+
+describe('WithdrawLockedFunds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('header', () => {
+    it('renders the title and the market-specific description', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: undefined,
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdraw funds locked in markets')).toBeInTheDocument();
+      expect(screen.getByText(/Closes all open positions on Polymarket/)).toBeInTheDocument();
+    });
+
+    it('uses the custom market name for cross-agent reuse', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: undefined,
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard({ marketName: 'Omen' });
+      expect(screen.getByText(/Closes all open positions on Omen/)).toBeInTheDocument();
+    });
+  });
+
+  describe('initial state', () => {
+    it('shows the locked amount and the initiate button', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: undefined,
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Open positions value')).toBeInTheDocument();
+      expect(screen.getByText('~$120.32')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeEnabled();
+    });
+
+    it('calls initiateWithdraw when the button is clicked', () => {
+      const initiateWithdraw = jest.fn().mockResolvedValue(undefined);
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: undefined,
+        initiateWithdraw,
+      });
+      renderCard();
+      fireEvent.click(screen.getByRole('button', { name: /initiate withdrawal/i }));
+      expect(initiateWithdraw).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows initiateWithdraw rejections so isError can drive the UI', async () => {
+      const initiateWithdraw = jest.fn().mockRejectedValue(new Error('boom'));
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: undefined,
+        initiateWithdraw,
+      });
+      renderCard();
+      fireEvent.click(screen.getByRole('button', { name: /initiate withdrawal/i }));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(initiateWithdraw).toHaveBeenCalled();
+    });
+  });
+
+  describe('in-progress state', () => {
+    it('renders the message coming from the backend with a spinner', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          status: 'withdrawing',
+          message: 'Withdrawal initiated. Selling open positions...',
+          transaction_link: null,
+        },
+        initiateWithdraw: jest.fn(),
+      });
+      const { container } = renderCard();
+      expect(
+        screen.getByText('Withdrawal initiated. Selling open positions...'),
+      ).toBeInTheDocument();
+      expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /initiate withdrawal/i })).toBeNull();
+    });
+
+    it('renders an empty message string without crashing when the backend omits one', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          status: 'initiated',
+          message: undefined,
+          transaction_link: null,
+        },
+        initiateWithdraw: jest.fn(),
+      });
+      const { container } = renderCard();
+      expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+    });
+  });
+
+  describe('done state', () => {
+    it('shows the success alert with transaction link', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          status: 'completed',
+          message: 'done',
+          transaction_link: 'https://example.com/tx',
+        },
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdrawal complete!')).toBeInTheDocument();
+      const link = screen.getByRole('link', { name: /view transaction details/i });
+      expect(link).toHaveAttribute('href', 'https://example.com/tx');
+      expect(screen.queryByText('Open positions value')).toBeNull();
+    });
+
+    it('omits the transaction link when none is returned', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: { status: 'completed', message: 'done', transaction_link: null },
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdrawal complete!')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /view transaction details/i })).toBeNull();
+    });
+
+    it('returns to the initial state when the success alert is dismissed', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: { status: 'completed', message: 'done', transaction_link: null },
+        initiateWithdraw: jest.fn(),
+      });
+      const { container } = renderCard();
+      const closeButton = container.querySelector('.ant-alert-close-icon');
+      if (!closeButton) throw new Error('Expected alert close button to be present');
+      fireEvent.click(closeButton);
+      expect(screen.queryByText('Withdrawal complete!')).toBeNull();
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    it('shows the failure alert above the initial state for retry', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: {
+          status: 'failed',
+          message: 'failed',
+          transaction_link: 'https://example.com/tx-fail',
+        },
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /last transaction details/i })).toHaveAttribute(
+        'href',
+        'https://example.com/tx-fail',
+      );
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
+    });
+
+    it('shows the failure alert when isError is true even without status data', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /last transaction details/i })).toBeNull();
+    });
+
+    it('retries via the initiate button after a failure', () => {
+      const initiateWithdraw = jest.fn().mockResolvedValue(undefined);
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: true,
+        data: undefined,
+        initiateWithdraw,
+      });
+      renderCard();
+      fireEvent.click(screen.getByRole('button', { name: /initiate withdrawal/i }));
+      expect(initiateWithdraw).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the failure alert when dismissed and shows the initial state', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: { status: 'failed', message: 'oops', transaction_link: null },
+        initiateWithdraw: jest.fn(),
+      });
+      const { container } = renderCard();
+      const closeButton = container.querySelector('.ant-alert-close-icon');
+      if (!closeButton) throw new Error('Expected alert close button to be present');
+      fireEvent.click(closeButton);
+      expect(screen.queryByText('Withdrawal failed')).toBeNull();
+      expect(screen.getByText('Open positions value')).toBeInTheDocument();
+    });
+
+    it('falls back to the initiate button (not the in-progress spinner) after dismissing a failure', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: { status: 'failed', message: 'oops', transaction_link: null },
+        initiateWithdraw: jest.fn(),
+      });
+      const { container } = renderCard();
+      const closeButton = container.querySelector('.ant-alert-close-icon');
+      if (!closeButton) throw new Error('Expected alert close button to be present');
+      fireEvent.click(closeButton);
+
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
+      expect(container.querySelector('.ant-spin')).toBeNull();
+    });
+  });
+
+  describe('loading state propagation', () => {
+    it('disables the initiate button while the hook reports loading', () => {
+      mockedHook.mockReturnValue({
+        isLoading: true,
+        isError: false,
+        data: undefined,
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      const button = screen.getByRole('button', { name: /initiate withdrawal/i });
+      expect(button).toHaveClass('ant-btn-loading');
+    });
+  });
+});

--- a/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
+++ b/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
@@ -2,7 +2,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { WithdrawLockedFunds } from '../../../src/components/WithdrawLockedFunds';
 import { useWithdrawLockedFunds } from '../../../src/hooks/useWithdrawLockedFunds';
-import { WithdrawalStatus } from '../../../src/types';
+import { WithdrawalFill, WithdrawalStatus } from '../../../src/types';
+
+const fakeFill: WithdrawalFill = {
+  token_id: '0xabc',
+  shares_sold: 1,
+  fill_price: 0.5,
+  ts: 1715021978,
+};
 
 jest.mock('../../../src/hooks/useWithdrawLockedFunds');
 
@@ -180,11 +187,11 @@ describe('WithdrawLockedFunds', () => {
   });
 
   describe('errored state', () => {
-    it('shows the failure alert above the initiate body when mode is errored', () => {
+    it('shows the failure alert above the initiate body when mode is errored with no fills', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: buildStatus({ mode: 'errored', positions_stuck: 2 }),
+        data: buildStatus({ mode: 'errored', positions_stuck: 2, fills: [] }),
         initiateWithdraw: jest.fn(),
       });
       renderCard();
@@ -262,6 +269,83 @@ describe('WithdrawLockedFunds', () => {
         isLoading: false,
         isError: false,
         data: buildStatus({ mode: 'errored' }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard({ lockedAmount: 0 });
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeDisabled();
+    });
+  });
+
+  describe('partial withdrawal state', () => {
+    it('shows the partial-withdrawal alert when mode=errored and at least one fill landed', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({
+          mode: 'errored',
+          positions_total: 3,
+          positions_sold: 2,
+          positions_stuck: 1,
+          fills: [fakeFill, fakeFill],
+        }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Partial withdrawal completed')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Some positions couldn't be sold\. Please try again to withdraw the remaining funds\./,
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Withdrawal failed')).toBeNull();
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
+    });
+
+    it('keeps showing the full-failure alert when mode=errored has no fills', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored', positions_stuck: 3, fills: [] }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
+      expect(screen.queryByText('Partial withdrawal completed')).toBeNull();
+    });
+
+    it('falls back to the initiate body after dismissing the partial alert', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored', fills: [fakeFill] }),
+        initiateWithdraw: jest.fn(),
+      });
+      const { container } = renderCard();
+      const closeButton = container.querySelector('.ant-alert-close-icon');
+      if (!closeButton) throw new Error('Expected alert close button to be present');
+      fireEvent.click(closeButton);
+      expect(screen.queryByText('Partial withdrawal completed')).toBeNull();
+      expect(screen.getByText('Open positions value')).toBeInTheDocument();
+    });
+
+    it('retries via the initiate button from the partial state', () => {
+      const initiateWithdraw = jest.fn().mockResolvedValue(undefined);
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored', fills: [fakeFill] }),
+        initiateWithdraw,
+      });
+      renderCard();
+      fireEvent.click(screen.getByRole('button', { name: /initiate withdrawal/i }));
+      expect(initiateWithdraw).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the retry button on the partial state when there are no locked funds', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored', fills: [fakeFill] }),
         initiateWithdraw: jest.fn(),
       });
       renderCard({ lockedAmount: 0 });

--- a/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
+++ b/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
@@ -66,6 +66,17 @@ describe('WithdrawLockedFunds', () => {
       expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeEnabled();
     });
 
+    it('disables the initiate button when there are no locked funds', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'idle' }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard({ lockedAmount: 0 });
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeDisabled();
+    });
+
     it('falls through to the initiate body when no status data has loaded yet', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
@@ -244,6 +255,17 @@ describe('WithdrawLockedFunds', () => {
       expect(screen.queryByText('Withdrawal failed')).toBeNull();
       expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
       expect(container.querySelector('.ant-spin')).toBeNull();
+    });
+
+    it('disables the retry button when there are no locked funds', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored' }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard({ lockedAmount: 0 });
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeDisabled();
     });
   });
 

--- a/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
+++ b/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { WithdrawLockedFunds } from '../../../src/components/WithdrawLockedFunds';
 import { useWithdrawLockedFunds } from '../../../src/hooks/useWithdrawLockedFunds';
@@ -118,9 +118,7 @@ describe('WithdrawLockedFunds', () => {
       });
       renderCard();
       fireEvent.click(screen.getByRole('button', { name: /initiate withdrawal/i }));
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(initiateWithdraw).toHaveBeenCalled();
+      await waitFor(() => expect(initiateWithdraw).toHaveBeenCalled());
     });
   });
 

--- a/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
+++ b/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
@@ -196,31 +196,7 @@ describe('WithdrawLockedFunds', () => {
       });
       renderCard();
       expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
-      expect(screen.getByText('2 positions stuck')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
-    });
-
-    it('singularizes "1 position stuck"', () => {
-      mockedHook.mockReturnValue({
-        isLoading: false,
-        isError: false,
-        data: buildStatus({ mode: 'errored', positions_stuck: 1 }),
-        initiateWithdraw: jest.fn(),
-      });
-      renderCard();
-      expect(screen.getByText('1 position stuck')).toBeInTheDocument();
-    });
-
-    it('omits the stuck-count chip when zero positions are stuck', () => {
-      mockedHook.mockReturnValue({
-        isLoading: false,
-        isError: false,
-        data: buildStatus({ mode: 'errored', positions_stuck: 0 }),
-        initiateWithdraw: jest.fn(),
-      });
-      renderCard();
-      expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
-      expect(screen.queryByText(/positions? stuck/)).toBeNull();
     });
 
     it('shows the failure alert when isError is true even without status data', () => {

--- a/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
+++ b/apps/predict-ui/__tests__/components/WithdrawLockedFunds/WithdrawLockedFunds.spec.tsx
@@ -2,10 +2,22 @@ import { fireEvent, render, screen } from '@testing-library/react';
 
 import { WithdrawLockedFunds } from '../../../src/components/WithdrawLockedFunds';
 import { useWithdrawLockedFunds } from '../../../src/hooks/useWithdrawLockedFunds';
+import { WithdrawalStatus } from '../../../src/types';
 
 jest.mock('../../../src/hooks/useWithdrawLockedFunds');
 
 const mockedHook = useWithdrawLockedFunds as jest.Mock;
+
+const buildStatus = (overrides: Partial<WithdrawalStatus> = {}): WithdrawalStatus => ({
+  mode: 'idle',
+  venue: 'polymarket',
+  positions_total: 0,
+  positions_sold: 0,
+  positions_stuck: 0,
+  fills: [],
+  errors: [],
+  ...overrides,
+});
 
 const renderCard = (props?: Partial<React.ComponentProps<typeof WithdrawLockedFunds>>) =>
   render(<WithdrawLockedFunds lockedAmount={120.32} marketName="Polymarket" {...(props ?? {})} />);
@@ -20,7 +32,7 @@ describe('WithdrawLockedFunds', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: undefined,
+        data: buildStatus(),
         initiateWithdraw: jest.fn(),
       });
       renderCard();
@@ -32,7 +44,7 @@ describe('WithdrawLockedFunds', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: undefined,
+        data: buildStatus(),
         initiateWithdraw: jest.fn(),
       });
       renderCard({ marketName: 'Omen' });
@@ -40,12 +52,12 @@ describe('WithdrawLockedFunds', () => {
     });
   });
 
-  describe('initial state', () => {
-    it('shows the locked amount and the initiate button', () => {
+  describe('idle / initial state', () => {
+    it('shows the locked amount and the initiate button when mode is idle', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: undefined,
+        data: buildStatus({ mode: 'idle' }),
         initiateWithdraw: jest.fn(),
       });
       renderCard();
@@ -54,12 +66,23 @@ describe('WithdrawLockedFunds', () => {
       expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeEnabled();
     });
 
+    it('falls through to the initiate body when no status data has loaded yet', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: undefined,
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
+    });
+
     it('calls initiateWithdraw when the button is clicked', () => {
       const initiateWithdraw = jest.fn().mockResolvedValue(undefined);
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: undefined,
+        data: buildStatus(),
         initiateWithdraw,
       });
       renderCard();
@@ -72,7 +95,7 @@ describe('WithdrawLockedFunds', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: undefined,
+        data: buildStatus(),
         initiateWithdraw,
       });
       renderCard();
@@ -84,77 +107,56 @@ describe('WithdrawLockedFunds', () => {
   });
 
   describe('in-progress state', () => {
-    it('renders the message coming from the backend with a spinner', () => {
+    it('shows the armed-state message when the agent has been armed but not started', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: {
-          status: 'withdrawing',
-          message: 'Withdrawal initiated. Selling open positions...',
-          transaction_link: null,
-        },
+        data: buildStatus({ mode: 'armed' }),
         initiateWithdraw: jest.fn(),
       });
       const { container } = renderCard();
       expect(
-        screen.getByText('Withdrawal initiated. Selling open positions...'),
+        screen.getByText(
+          'Withdrawal requested. Waiting for the agent to complete its current actions...',
+        ),
       ).toBeInTheDocument();
       expect(container.querySelector('.ant-spin')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /initiate withdrawal/i })).toBeNull();
     });
 
-    it('renders an empty message string without crashing when the backend omits one', () => {
+    it('shows the selling-state message when the sweep is in progress', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: {
-          status: 'initiated',
-          message: undefined,
-          transaction_link: null,
-        },
+        data: buildStatus({ mode: 'selling', positions_sold: 4, positions_total: 7 }),
         initiateWithdraw: jest.fn(),
       });
-      const { container } = renderCard();
-      expect(container.querySelector('.ant-spin')).toBeInTheDocument();
+      renderCard();
+      expect(
+        screen.getByText('Withdrawal initiated. Selling open positions...'),
+      ).toBeInTheDocument();
     });
   });
 
-  describe('done state', () => {
-    it('shows the success alert with transaction link', () => {
+  describe('complete state', () => {
+    it('shows the success alert with the marketName-specific copy', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: {
-          status: 'completed',
-          message: 'done',
-          transaction_link: 'https://example.com/tx',
-        },
+        data: buildStatus({ mode: 'complete' }),
         initiateWithdraw: jest.fn(),
       });
       renderCard();
       expect(screen.getByText('Withdrawal complete!')).toBeInTheDocument();
-      const link = screen.getByRole('link', { name: /view transaction details/i });
-      expect(link).toHaveAttribute('href', 'https://example.com/tx');
+      expect(screen.getByText(/Polymarket positions have been sold/)).toBeInTheDocument();
       expect(screen.queryByText('Open positions value')).toBeNull();
     });
 
-    it('omits the transaction link when none is returned', () => {
+    it('returns to the initiate body when the success alert is dismissed', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: { status: 'completed', message: 'done', transaction_link: null },
-        initiateWithdraw: jest.fn(),
-      });
-      renderCard();
-      expect(screen.getByText('Withdrawal complete!')).toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: /view transaction details/i })).toBeNull();
-    });
-
-    it('returns to the initial state when the success alert is dismissed', () => {
-      mockedHook.mockReturnValue({
-        isLoading: false,
-        isError: false,
-        data: { status: 'completed', message: 'done', transaction_link: null },
+        data: buildStatus({ mode: 'complete' }),
         initiateWithdraw: jest.fn(),
       });
       const { container } = renderCard();
@@ -166,25 +168,41 @@ describe('WithdrawLockedFunds', () => {
     });
   });
 
-  describe('error state', () => {
-    it('shows the failure alert above the initial state for retry', () => {
+  describe('errored state', () => {
+    it('shows the failure alert above the initiate body when mode is errored', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: {
-          status: 'failed',
-          message: 'failed',
-          transaction_link: 'https://example.com/tx-fail',
-        },
+        data: buildStatus({ mode: 'errored', positions_stuck: 2 }),
         initiateWithdraw: jest.fn(),
       });
       renderCard();
       expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /last transaction details/i })).toHaveAttribute(
-        'href',
-        'https://example.com/tx-fail',
-      );
+      expect(screen.getByText('2 positions stuck')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
+    });
+
+    it('singularizes "1 position stuck"', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored', positions_stuck: 1 }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('1 position stuck')).toBeInTheDocument();
+    });
+
+    it('omits the stuck-count chip when zero positions are stuck', () => {
+      mockedHook.mockReturnValue({
+        isLoading: false,
+        isError: false,
+        data: buildStatus({ mode: 'errored', positions_stuck: 0 }),
+        initiateWithdraw: jest.fn(),
+      });
+      renderCard();
+      expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
+      expect(screen.queryByText(/positions? stuck/)).toBeNull();
     });
 
     it('shows the failure alert when isError is true even without status data', () => {
@@ -196,7 +214,6 @@ describe('WithdrawLockedFunds', () => {
       });
       renderCard();
       expect(screen.getByText('Withdrawal failed')).toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: /last transaction details/i })).toBeNull();
     });
 
     it('retries via the initiate button after a failure', () => {
@@ -212,44 +229,30 @@ describe('WithdrawLockedFunds', () => {
       expect(initiateWithdraw).toHaveBeenCalledTimes(1);
     });
 
-    it('hides the failure alert when dismissed and shows the initial state', () => {
+    it('falls back to the initiate body (not the spinner) after dismissing a failure', () => {
       mockedHook.mockReturnValue({
         isLoading: false,
         isError: false,
-        data: { status: 'failed', message: 'oops', transaction_link: null },
+        data: buildStatus({ mode: 'errored' }),
         initiateWithdraw: jest.fn(),
       });
       const { container } = renderCard();
       const closeButton = container.querySelector('.ant-alert-close-icon');
       if (!closeButton) throw new Error('Expected alert close button to be present');
       fireEvent.click(closeButton);
+
       expect(screen.queryByText('Withdrawal failed')).toBeNull();
-      expect(screen.getByText('Open positions value')).toBeInTheDocument();
-    });
-
-    it('falls back to the initiate button (not the in-progress spinner) after dismissing a failure', () => {
-      mockedHook.mockReturnValue({
-        isLoading: false,
-        isError: false,
-        data: { status: 'failed', message: 'oops', transaction_link: null },
-        initiateWithdraw: jest.fn(),
-      });
-      const { container } = renderCard();
-      const closeButton = container.querySelector('.ant-alert-close-icon');
-      if (!closeButton) throw new Error('Expected alert close button to be present');
-      fireEvent.click(closeButton);
-
       expect(screen.getByRole('button', { name: /initiate withdrawal/i })).toBeInTheDocument();
       expect(container.querySelector('.ant-spin')).toBeNull();
     });
   });
 
   describe('loading state propagation', () => {
-    it('disables the initiate button while the hook reports loading', () => {
+    it('shows the initiate button in loading state while the hook reports loading', () => {
       mockedHook.mockReturnValue({
         isLoading: true,
         isError: false,
-        data: undefined,
+        data: buildStatus({ mode: 'idle' }),
         initiateWithdraw: jest.fn(),
       });
       renderCard();

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
@@ -23,7 +23,11 @@ describe('useWithdrawLockedFunds — dev mock mode', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
   });
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    const g = global as unknown as Record<string, unknown>;
+    delete g['fetch'];
+    jest.restoreAllMocks();
+  });
 
   it('returns the mocked status after initiateWithdraw, without calling fetch', async () => {
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
@@ -1,12 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
 
 import { useWithdrawLockedFunds } from '../../src/hooks/useWithdrawLockedFunds';
-import {
-  mockWithdrawInitiateResponse,
-  mockWithdrawStatusResponse,
-} from '../../src/mocks/mockWithdrawal';
+import { mockWithdrawalStatus } from '../../src/mocks/mockWithdrawal';
 
 jest.mock('@agent-ui-monorepo/util-functions', () => ({
   ...jest.requireActual('@agent-ui-monorepo/util-functions'),
@@ -28,15 +25,10 @@ describe('useWithdrawLockedFunds — dev mock mode', () => {
   });
   afterEach(() => jest.restoreAllMocks());
 
-  it('returns mock initiate and status without calling fetch', async () => {
+  it('returns the mocked status without calling fetch', async () => {
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
 
-    await act(async () => {
-      await result.current.initiateWithdraw();
-    });
-
-    await waitFor(() => expect(result.current.data).toEqual(mockWithdrawStatusResponse));
+    await waitFor(() => expect(result.current.data).toEqual(mockWithdrawalStatus));
     expect(global.fetch).not.toHaveBeenCalled();
-    expect(mockWithdrawInitiateResponse.id).toBe('550e8400-e29b-41d4-a716-446655440000');
   });
 });

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
@@ -1,0 +1,42 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+
+import { useWithdrawLockedFunds } from '../../src/hooks/useWithdrawLockedFunds';
+import {
+  mockWithdrawInitiateResponse,
+  mockWithdrawStatusResponse,
+} from '../../src/mocks/mockWithdrawal';
+
+jest.mock('@agent-ui-monorepo/util-functions', () => ({
+  ...jest.requireActual('@agent-ui-monorepo/util-functions'),
+  devMock: <T>(fn: () => T) => fn(),
+  delay: <T>(value: T) => Promise.resolve(value),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useWithdrawLockedFunds — dev mock mode', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns mock initiate and status without calling fetch', async () => {
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.initiateWithdraw();
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(mockWithdrawStatusResponse));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockWithdrawInitiateResponse.id).toBe('550e8400-e29b-41d4-a716-446655440000');
+  });
+});

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.mock.spec.ts
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { createElement } from 'react';
 
 import { useWithdrawLockedFunds } from '../../src/hooks/useWithdrawLockedFunds';
@@ -25,8 +25,14 @@ describe('useWithdrawLockedFunds — dev mock mode', () => {
   });
   afterEach(() => jest.restoreAllMocks());
 
-  it('returns the mocked status without calling fetch', async () => {
+  it('returns the mocked status after initiateWithdraw, without calling fetch', async () => {
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+
+    expect(result.current.data).toBeUndefined();
+
+    await act(async () => {
+      await result.current.initiateWithdraw();
+    });
 
     await waitFor(() => expect(result.current.data).toEqual(mockWithdrawalStatus));
     expect(global.fetch).not.toHaveBeenCalled();

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
@@ -18,11 +18,15 @@ type QueryConfig = {
 const mockUseMutation = jest.fn();
 const mockUseQuery = jest.fn();
 const mockSetQueryData = jest.fn();
+const mockRefetchQueries = jest.fn();
 
 jest.mock('@tanstack/react-query', () => ({
   useMutation: (config: MutationConfig) => mockUseMutation(config),
   useQuery: (config: QueryConfig) => mockUseQuery(config),
-  useQueryClient: () => ({ setQueryData: mockSetQueryData }),
+  useQueryClient: () => ({
+    setQueryData: mockSetQueryData,
+    refetchQueries: mockRefetchQueries,
+  }),
 }));
 
 describe('useWithdrawLockedFunds — query/mutation config', () => {
@@ -70,6 +74,39 @@ describe('useWithdrawLockedFunds — query/mutation config', () => {
   it('retries the status query indefinitely so transient errors are absorbed', () => {
     const cfg = captureQueryConfig();
     expect(cfg.retry).toBe(Infinity);
+  });
+
+  it('refetches the agent performance query when the sweep reaches complete', () => {
+    mockUseQuery.mockReturnValue({
+      data: { mode: 'complete' },
+      isLoading: false,
+      isError: false,
+    });
+    renderHook(() => useWithdrawLockedFunds());
+
+    expect(mockRefetchQueries).toHaveBeenCalledWith({ queryKey: ['agentPerformance'] });
+  });
+
+  it('refetches the agent performance query when the sweep reaches errored', () => {
+    mockUseQuery.mockReturnValue({
+      data: { mode: 'errored' },
+      isLoading: false,
+      isError: false,
+    });
+    renderHook(() => useWithdrawLockedFunds());
+
+    expect(mockRefetchQueries).toHaveBeenCalledWith({ queryKey: ['agentPerformance'] });
+  });
+
+  it('does NOT refetch the agent performance query for non-terminal modes', () => {
+    mockUseQuery.mockReturnValue({
+      data: { mode: 'selling' },
+      isLoading: false,
+      isError: false,
+    });
+    renderHook(() => useWithdrawLockedFunds());
+
+    expect(mockRefetchQueries).not.toHaveBeenCalled();
   });
 
   it('logs on mutation error', () => {

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
@@ -8,18 +8,19 @@ type MutationConfig = {
 };
 
 type QueryConfig = {
-  enabled: boolean;
   queryFn: () => Promise<unknown>;
-  refetchInterval: (query: { state: { data?: { status?: string } } }) => number | false;
+  refetchInterval: (query: { state: { data?: { mode?: string } } }) => number | false;
   retry: number;
 };
 
 const mockUseMutation = jest.fn();
 const mockUseQuery = jest.fn();
+const mockSetQueryData = jest.fn();
 
 jest.mock('@tanstack/react-query', () => ({
   useMutation: (config: MutationConfig) => mockUseMutation(config),
   useQuery: (config: QueryConfig) => mockUseQuery(config),
+  useQueryClient: () => ({ setQueryData: mockSetQueryData }),
 }));
 
 describe('useWithdrawLockedFunds — query/mutation config', () => {
@@ -45,22 +46,18 @@ describe('useWithdrawLockedFunds — query/mutation config', () => {
     return captured;
   };
 
-  it('disables the status query until withdrawId is set', () => {
+  it('polls every 2s while the agent is armed or selling', () => {
     const cfg = captureQueryConfig();
-    expect(cfg.enabled).toBe(false);
+    expect(cfg.refetchInterval({ state: { data: { mode: 'armed' } } })).toBe(2000);
+    expect(cfg.refetchInterval({ state: { data: { mode: 'selling' } } })).toBe(2000);
   });
 
-  it('polls every 2s for non-terminal statuses', () => {
+  it('stops polling when idle, complete, or errored', () => {
     const cfg = captureQueryConfig();
-    expect(cfg.refetchInterval({ state: { data: { status: 'initiated' } } })).toBe(2000);
-    expect(cfg.refetchInterval({ state: { data: { status: 'withdrawing' } } })).toBe(2000);
-    expect(cfg.refetchInterval({ state: {} })).toBe(2000);
-  });
-
-  it('stops polling on completed and failed statuses', () => {
-    const cfg = captureQueryConfig();
-    expect(cfg.refetchInterval({ state: { data: { status: 'completed' } } })).toBe(false);
-    expect(cfg.refetchInterval({ state: { data: { status: 'failed' } } })).toBe(false);
+    expect(cfg.refetchInterval({ state: { data: { mode: 'idle' } } })).toBe(false);
+    expect(cfg.refetchInterval({ state: { data: { mode: 'complete' } } })).toBe(false);
+    expect(cfg.refetchInterval({ state: { data: { mode: 'errored' } } })).toBe(false);
+    expect(cfg.refetchInterval({ state: {} })).toBe(false);
   });
 
   it('retries the status query indefinitely so transient errors are absorbed', () => {
@@ -68,7 +65,7 @@ describe('useWithdrawLockedFunds — query/mutation config', () => {
     expect(cfg.retry).toBe(Infinity);
   });
 
-  it('logs and clears withdrawId on mutation error', () => {
+  it('logs on mutation error', () => {
     let mutationCfg: MutationConfig | undefined;
     mockUseMutation.mockImplementation((config: MutationConfig) => {
       mutationCfg = config;
@@ -78,8 +75,8 @@ describe('useWithdrawLockedFunds — query/mutation config', () => {
     if (!mutationCfg) throw new Error('Expected mutation config to be captured');
 
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
-    mutationCfg.onError(new Error('initiate failed'));
-    expect(consoleErrorSpy).toHaveBeenCalledWith('Error initiating withdrawal:', expect.any(Error));
+    mutationCfg.onError(new Error('arm failed'));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error arming withdrawal:', expect.any(Error));
     consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
@@ -1,0 +1,85 @@
+import { renderHook } from '@testing-library/react';
+
+import { useWithdrawLockedFunds } from '../../src/hooks/useWithdrawLockedFunds';
+
+type MutationConfig = {
+  mutationFn: () => Promise<unknown>;
+  onError: (error: unknown) => void;
+};
+
+type QueryConfig = {
+  enabled: boolean;
+  queryFn: () => Promise<unknown>;
+  refetchInterval: (query: { state: { data?: { status?: string } } }) => number | false;
+  retry: number;
+};
+
+const mockUseMutation = jest.fn();
+const mockUseQuery = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: (config: MutationConfig) => mockUseMutation(config),
+  useQuery: (config: QueryConfig) => mockUseQuery(config),
+}));
+
+describe('useWithdrawLockedFunds — query/mutation config', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseMutation.mockReturnValue({
+      isPending: false,
+      isError: false,
+      mutateAsync: jest.fn(),
+      reset: jest.fn(),
+    });
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+  });
+
+  const captureQueryConfig = () => {
+    let captured: QueryConfig | undefined;
+    mockUseQuery.mockImplementation((config: QueryConfig) => {
+      captured = config;
+      return { data: undefined, isLoading: false, isError: false };
+    });
+    renderHook(() => useWithdrawLockedFunds());
+    if (!captured) throw new Error('Expected query config to be captured');
+    return captured;
+  };
+
+  it('disables the status query until withdrawId is set', () => {
+    const cfg = captureQueryConfig();
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('polls every 2s for non-terminal statuses', () => {
+    const cfg = captureQueryConfig();
+    expect(cfg.refetchInterval({ state: { data: { status: 'initiated' } } })).toBe(2000);
+    expect(cfg.refetchInterval({ state: { data: { status: 'withdrawing' } } })).toBe(2000);
+    expect(cfg.refetchInterval({ state: {} })).toBe(2000);
+  });
+
+  it('stops polling on completed and failed statuses', () => {
+    const cfg = captureQueryConfig();
+    expect(cfg.refetchInterval({ state: { data: { status: 'completed' } } })).toBe(false);
+    expect(cfg.refetchInterval({ state: { data: { status: 'failed' } } })).toBe(false);
+  });
+
+  it('retries the status query indefinitely so transient errors are absorbed', () => {
+    const cfg = captureQueryConfig();
+    expect(cfg.retry).toBe(Infinity);
+  });
+
+  it('logs and clears withdrawId on mutation error', () => {
+    let mutationCfg: MutationConfig | undefined;
+    mockUseMutation.mockImplementation((config: MutationConfig) => {
+      mutationCfg = config;
+      return { isPending: false, isError: false, mutateAsync: jest.fn(), reset: jest.fn() };
+    });
+    renderHook(() => useWithdrawLockedFunds());
+    if (!mutationCfg) throw new Error('Expected mutation config to be captured');
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    mutationCfg.onError(new Error('initiate failed'));
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error initiating withdrawal:', expect.any(Error));
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.refetch.spec.tsx
@@ -4,10 +4,12 @@ import { useWithdrawLockedFunds } from '../../src/hooks/useWithdrawLockedFunds';
 
 type MutationConfig = {
   mutationFn: () => Promise<unknown>;
+  onSuccess: (data: unknown) => void;
   onError: (error: unknown) => void;
 };
 
 type QueryConfig = {
+  enabled: boolean;
   queryFn: () => Promise<unknown>;
   refetchInterval: (query: { state: { data?: { mode?: string } } }) => number | false;
   retry: number;
@@ -45,6 +47,11 @@ describe('useWithdrawLockedFunds — query/mutation config', () => {
     if (!captured) throw new Error('Expected query config to be captured');
     return captured;
   };
+
+  it('keeps the status query disabled until the user initiates', () => {
+    const cfg = captureQueryConfig();
+    expect(cfg.enabled).toBe(false);
+  });
 
   it('polls every 2s while the agent is armed or selling', () => {
     const cfg = captureQueryConfig();

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.spec.ts
@@ -12,11 +12,24 @@ const createWrapper = () => {
     createElement(QueryClientProvider, { client: queryClient }, children);
 };
 
-const mockInitiateResponse = { id: 'wd-1', status: 'initiated' };
-const mockStatusResponse = {
-  status: 'withdrawing',
-  message: 'Selling open positions...',
-  transaction_link: null,
+const mockIdleStatus = {
+  mode: 'idle',
+  venue: 'polymarket',
+  positions_total: 0,
+  positions_sold: 0,
+  positions_stuck: 0,
+  fills: [],
+  errors: [],
+};
+
+const mockSellingStatus = {
+  mode: 'selling',
+  venue: 'polymarket',
+  positions_total: 7,
+  positions_sold: 4,
+  positions_stuck: 0,
+  fills: [],
+  errors: [],
 };
 
 describe('useWithdrawLockedFunds', () => {
@@ -30,17 +43,32 @@ describe('useWithdrawLockedFunds', () => {
     jest.restoreAllMocks();
   });
 
-  it('exposes initiateWithdraw and starts in a non-loading state', () => {
+  it('fetches the current status on mount via GET /api/v1/withdrawal', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockIdleStatus),
+    });
+
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
-    expect(typeof result.current.initiateWithdraw).toBe('function');
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.data).toBeUndefined();
+
+    await waitFor(() => expect(result.current.data?.mode).toBe('idle'));
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/v1/withdrawal'));
   });
 
-  it('POSTs to /withdrawal/initiate with no body when initiateWithdraw is called', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockInitiateResponse) })
-      .mockResolvedValue({ ok: true, json: () => Promise.resolve(mockStatusResponse) });
+  it('exposes initiateWithdraw and starts in a non-loading mutation state', () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockIdleStatus),
+    });
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    expect(typeof result.current.initiateWithdraw).toBe('function');
+  });
+
+  it('POSTs to /api/v1/withdrawal with no body when initiateWithdraw is called', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockSellingStatus),
+    });
 
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
     await act(async () => {
@@ -48,48 +76,38 @@ describe('useWithdrawLockedFunds', () => {
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/withdrawal/initiate'),
+      expect.stringContaining('/api/v1/withdrawal'),
       expect.objectContaining({ method: 'POST' }),
     );
-    const initiateCall = (global.fetch as jest.Mock).mock.calls.find(([url]) =>
-      String(url).includes('/withdrawal/initiate'),
+    const postCall = (global.fetch as jest.Mock).mock.calls.find(
+      ([, init]) => init?.method === 'POST',
     );
-    expect(initiateCall?.[1]?.body).toBeUndefined();
+    expect(postCall?.[1]?.body).toBeUndefined();
   });
 
-  it('hits the status endpoint with the id returned from initiate', async () => {
+  it('pushes the POST response into the query cache so the UI updates immediately', async () => {
     (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockInitiateResponse) })
-      .mockResolvedValue({ ok: true, json: () => Promise.resolve(mockStatusResponse) });
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockIdleStatus) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockSellingStatus) });
 
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.data?.mode).toBe('idle'));
+
     await act(async () => {
       await result.current.initiateWithdraw();
     });
 
-    await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/withdrawal/status/wd-1')),
-    );
+    await waitFor(() => expect(result.current.data?.mode).toBe('selling'));
+    expect(result.current.data?.positions_total).toBe(7);
   });
 
-  it('keeps data undefined while the status query retries on a non-ok response', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockInitiateResponse) })
-      .mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
-
-    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
-    await act(async () => {
-      await result.current.initiateWithdraw();
+  it('returns isError=true when the POST fails', async () => {
+    (global.fetch as jest.Mock).mockImplementation((_url, init?: { method?: string }) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockIdleStatus) });
     });
-
-    await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/withdrawal/status/')),
-    );
-    expect(result.current.data).toBeUndefined();
-  });
-
-  it('returns isError=true when the initiate POST fails', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
@@ -103,5 +121,19 @@ describe('useWithdrawLockedFunds', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     consoleErrorSpy.mockRestore();
+  });
+
+  it('keeps data undefined while the GET retries on a non-ok response', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({}),
+    });
+
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/v1/withdrawal')),
+    );
+    expect(result.current.data).toBeUndefined();
   });
 });

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.spec.ts
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement } from 'react';
+
+import { useWithdrawLockedFunds } from '../../src/hooks/useWithdrawLockedFunds';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+const mockInitiateResponse = { id: 'wd-1', status: 'initiated' };
+const mockStatusResponse = {
+  status: 'withdrawing',
+  message: 'Selling open positions...',
+  transaction_link: null,
+};
+
+describe('useWithdrawLockedFunds', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    const g = global as unknown as Record<string, unknown>;
+    delete g['fetch'];
+    jest.restoreAllMocks();
+  });
+
+  it('exposes initiateWithdraw and starts in a non-loading state', () => {
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    expect(typeof result.current.initiateWithdraw).toBe('function');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('POSTs to /withdrawal/initiate with no body when initiateWithdraw is called', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockInitiateResponse) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve(mockStatusResponse) });
+
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.initiateWithdraw();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/withdrawal/initiate'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const initiateCall = (global.fetch as jest.Mock).mock.calls.find(([url]) =>
+      String(url).includes('/withdrawal/initiate'),
+    );
+    expect(initiateCall?.[1]?.body).toBeUndefined();
+  });
+
+  it('hits the status endpoint with the id returned from initiate', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockInitiateResponse) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve(mockStatusResponse) });
+
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.initiateWithdraw();
+    });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/withdrawal/status/wd-1')),
+    );
+  });
+
+  it('keeps data undefined while the status query retries on a non-ok response', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockInitiateResponse) })
+      .mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
+
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.initiateWithdraw();
+    });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/withdrawal/status/')),
+    );
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('returns isError=true when the initiate POST fails', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+
+    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    await act(async () => {
+      try {
+        await result.current.initiateWithdraw();
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.spec.ts
+++ b/apps/predict-ui/__tests__/hooks/useWithdrawLockedFunds.spec.ts
@@ -12,16 +12,6 @@ const createWrapper = () => {
     createElement(QueryClientProvider, { client: queryClient }, children);
 };
 
-const mockIdleStatus = {
-  mode: 'idle',
-  venue: 'polymarket',
-  positions_total: 0,
-  positions_sold: 0,
-  positions_stuck: 0,
-  fills: [],
-  errors: [],
-};
-
 const mockSellingStatus = {
   mode: 'selling',
   venue: 'polymarket',
@@ -43,25 +33,25 @@ describe('useWithdrawLockedFunds', () => {
     jest.restoreAllMocks();
   });
 
-  it('fetches the current status on mount via GET /api/v1/withdrawal', async () => {
+  it('does NOT call the withdrawal API on mount — only after the user initiates', () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(mockIdleStatus),
+      json: () => Promise.resolve(mockSellingStatus),
     });
 
-    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
+    renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
 
-    await waitFor(() => expect(result.current.data?.mode).toBe('idle'));
-    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/v1/withdrawal'));
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('exposes initiateWithdraw and starts in a non-loading mutation state', () => {
+  it('exposes initiateWithdraw and starts with no data', () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve(mockIdleStatus),
+      json: () => Promise.resolve(mockSellingStatus),
     });
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
     expect(typeof result.current.initiateWithdraw).toBe('function');
+    expect(result.current.data).toBeUndefined();
   });
 
   it('POSTs to /api/v1/withdrawal with no body when initiateWithdraw is called', async () => {
@@ -86,12 +76,12 @@ describe('useWithdrawLockedFunds', () => {
   });
 
   it('pushes the POST response into the query cache so the UI updates immediately', async () => {
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockIdleStatus) })
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(mockSellingStatus) });
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockSellingStatus),
+    });
 
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
-    await waitFor(() => expect(result.current.data?.mode).toBe('idle'));
 
     await act(async () => {
       await result.current.initiateWithdraw();
@@ -102,12 +92,7 @@ describe('useWithdrawLockedFunds', () => {
   });
 
   it('returns isError=true when the POST fails', async () => {
-    (global.fetch as jest.Mock).mockImplementation((_url, init?: { method?: string }) => {
-      if (init?.method === 'POST') {
-        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
-      }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockIdleStatus) });
-    });
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, json: () => Promise.resolve({}) });
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
@@ -121,19 +106,5 @@ describe('useWithdrawLockedFunds', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     consoleErrorSpy.mockRestore();
-  });
-
-  it('keeps data undefined while the GET retries on a non-ok response', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      json: () => Promise.resolve({}),
-    });
-
-    const { result } = renderHook(() => useWithdrawLockedFunds(), { wrapper: createWrapper() });
-
-    await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/v1/withdrawal')),
-    );
-    expect(result.current.data).toBeUndefined();
   });
 });

--- a/apps/predict-ui/src/app/agent.tsx
+++ b/apps/predict-ui/src/app/agent.tsx
@@ -11,9 +11,11 @@ import { ProfitOverTime } from '../components/ProfitOverTime/ProfitOverTime';
 import { Strategy } from '../components/Strategy';
 import { TradeHistory } from '../components/TradeHistory/TradeHistory';
 import { Card } from '../components/ui/Card';
+import { WithdrawLockedFunds } from '../components/WithdrawLockedFunds';
 import { COLOR } from '../constants/theme';
 import { useAgentDetails } from '../hooks/useAgentDetails';
 import { useFeatures } from '../hooks/useFeatures';
+import { isPolystratAgent } from '../utils/agentMap';
 
 const AgentContent = styled.div`
   display: flex;
@@ -113,6 +115,12 @@ export const Agent = () => {
         <TradeHistory />
         <Strategy />
         <ChatContent />
+        {isPolystratAgent && (
+          <WithdrawLockedFunds
+            lockedAmount={performance.metrics.funds_locked_in_markets}
+            marketName="Polymarket"
+          />
+        )}
       </AgentContent>
     </Flex>
   );

--- a/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
+++ b/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
@@ -1,6 +1,6 @@
 import { InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import { Alert as AntdAlert, Button, Flex, Spin, Tooltip, Typography } from 'antd';
-import { ExternalLink, Info, TriangleAlert, X } from 'lucide-react';
+import { Info, TriangleAlert, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 
@@ -8,7 +8,7 @@ import { COLOR } from '../../constants/theme';
 import { useWithdrawLockedFunds } from '../../hooks/useWithdrawLockedFunds';
 import { Card } from '../ui/Card';
 
-const { Title, Text, Link } = Typography;
+const { Title, Text } = Typography;
 
 const POSITIONS_TOOLTIP =
   'Estimated value of all open positions at current market prices. Final value may differ at withdrawal.';
@@ -93,23 +93,27 @@ const InitiateBody = ({ amount, isLoading, onInitiate }: InitiateProps) => (
   </>
 );
 
-const SellingBody = ({ amount, message }: { amount: number; message: string }) => (
+const SELLING_MESSAGE: Record<'armed' | 'selling', string> = {
+  armed: 'Withdrawal requested. Waiting for the agent to complete its current actions...',
+  selling: 'Withdrawal initiated. Selling open positions...',
+};
+
+type SellingProps = {
+  amount: number;
+  mode: 'armed' | 'selling';
+};
+
+const SellingBody = ({ amount, mode }: SellingProps) => (
   <>
     <OpenPositionsValue amount={amount} />
     <Flex gap={8} align="center">
       <Spin indicator={<LoadingOutlined spin style={{ color: COLOR.TEXT_PRIMARY }} />} />
-      <Text type="secondary">{message}</Text>
+      <Text type="secondary">{SELLING_MESSAGE[mode]}</Text>
     </Flex>
   </>
 );
 
-type DoneBodyProps = {
-  marketName: string;
-  transactionLink: string | null;
-  onDismiss: () => void;
-};
-
-const DoneBody = ({ marketName, transactionLink, onDismiss }: DoneBodyProps) => (
+const DoneBody = ({ marketName, onDismiss }: { marketName: string; onDismiss: () => void }) => (
   <SuccessAlert
     icon={<Info size={16} color={COLOR.GREEN} />}
     showIcon
@@ -118,29 +122,10 @@ const DoneBody = ({ marketName, transactionLink, onDismiss }: DoneBodyProps) => 
     onClose={onDismiss}
     message={<span style={{ fontWeight: 500 }}>Withdrawal complete!</span>}
     description={
-      <Flex vertical gap={8} style={{ maxWidth: 470 }}>
-        <span>
-          {marketName} positions have been sold, and funds are now in your Agent Wallet in Pearl.
-          The agent has stopped trading and will continue when restarted.
-        </span>
-        {transactionLink && (
-          <Link
-            href={transactionLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              color: COLOR.SECONDARY,
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 6,
-              fontSize: 14,
-            }}
-          >
-            View transaction details
-            <ExternalLink size={14} />
-          </Link>
-        )}
-      </Flex>
+      <span style={{ display: 'inline-block', maxWidth: 470 }}>
+        {marketName} positions have been sold, and funds are now in your Agent Wallet in Pearl. The
+        agent has stopped trading and will continue when restarted.
+      </span>
     }
   />
 );
@@ -148,12 +133,12 @@ const DoneBody = ({ marketName, transactionLink, onDismiss }: DoneBodyProps) => 
 type ErrorBodyProps = {
   amount: number;
   isLoading: boolean;
-  transactionLink: string | null;
+  positionsStuck: number;
   onRetry: () => void;
   onDismiss: () => void;
 };
 
-const ErrorBody = ({ amount, isLoading, transactionLink, onRetry, onDismiss }: ErrorBodyProps) => (
+const ErrorBody = ({ amount, isLoading, positionsStuck, onRetry, onDismiss }: ErrorBodyProps) => (
   <>
     <ErrorAlert
       icon={<TriangleAlert size={16} color={COLOR.RED} />}
@@ -164,21 +149,10 @@ const ErrorBody = ({ amount, isLoading, transactionLink, onRetry, onDismiss }: E
       message={
         <Flex gap={8} align="center">
           <span style={{ fontWeight: 500 }}>Withdrawal failed</span>
-          {transactionLink && (
-            <Link
-              href={transactionLink}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                color: COLOR.SECONDARY,
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
-              <span style={{ fontSize: 14 }}>Last transaction details</span>
-              <ExternalLink size={14} />
-            </Link>
+          {positionsStuck > 0 && (
+            <Text style={{ color: COLOR.SECONDARY, fontSize: 14 }}>
+              {positionsStuck} {positionsStuck === 1 ? 'position' : 'positions'} stuck
+            </Text>
           )}
         </Flex>
       }
@@ -214,33 +188,27 @@ export const WithdrawLockedFunds = ({ lockedAmount, marketName }: WithdrawLocked
     setIsResultDismissed(true);
   }, []);
 
-  const status = data?.status;
-
   const renderBody = () => {
+    const mode = data?.mode;
+
     if (!isResultDismissed) {
-      if (status === 'completed') {
-        return (
-          <DoneBody
-            marketName={marketName}
-            transactionLink={data?.transaction_link ?? null}
-            onDismiss={handleDismiss}
-          />
-        );
+      if (mode === 'complete') {
+        return <DoneBody marketName={marketName} onDismiss={handleDismiss} />;
       }
-      if (status === 'failed' || isError) {
+      if (mode === 'errored' || isError) {
         return (
           <ErrorBody
             amount={lockedAmount}
             isLoading={isLoading}
-            transactionLink={data?.transaction_link ?? null}
+            positionsStuck={data?.positions_stuck ?? 0}
             onRetry={handleInitiate}
             onDismiss={handleDismiss}
           />
         );
       }
     }
-    if (status === 'initiated' || status === 'withdrawing') {
-      return <SellingBody amount={lockedAmount} message={data?.message ?? ''} />;
+    if (mode === 'armed' || mode === 'selling') {
+      return <SellingBody amount={lockedAmount} mode={mode} />;
     }
     return <InitiateBody amount={lockedAmount} isLoading={isLoading} onInitiate={handleInitiate} />;
   };

--- a/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
+++ b/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
@@ -87,7 +87,7 @@ type InitiateProps = {
 const InitiateBody = ({ amount, isLoading, onInitiate }: InitiateProps) => (
   <>
     <OpenPositionsValue amount={amount} />
-    <InitiateButton onClick={onInitiate} loading={isLoading}>
+    <InitiateButton onClick={onInitiate} loading={isLoading} disabled={amount <= 0}>
       Initiate withdrawal
     </InitiateButton>
   </>
@@ -158,7 +158,7 @@ const ErrorBody = ({ amount, isLoading, positionsStuck, onRetry, onDismiss }: Er
       }
     />
     <OpenPositionsValue amount={amount} />
-    <InitiateButton onClick={onRetry} loading={isLoading}>
+    <InitiateButton onClick={onRetry} loading={isLoading} disabled={amount <= 0}>
       Initiate withdrawal
     </InitiateButton>
   </>

--- a/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
+++ b/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
@@ -173,12 +173,11 @@ const PartialBody = ({ amount, isLoading, onRetry, onDismiss }: PartialBodyProps
 type ErrorBodyProps = {
   amount: number;
   isLoading: boolean;
-  positionsStuck: number;
   onRetry: () => void;
   onDismiss: () => void;
 };
 
-const ErrorBody = ({ amount, isLoading, positionsStuck, onRetry, onDismiss }: ErrorBodyProps) => (
+const ErrorBody = ({ amount, isLoading, onRetry, onDismiss }: ErrorBodyProps) => (
   <>
     <ErrorAlert
       icon={<TriangleAlert size={16} color={COLOR.RED} />}
@@ -186,16 +185,7 @@ const ErrorBody = ({ amount, isLoading, positionsStuck, onRetry, onDismiss }: Er
       closable
       closeIcon={<X size={16} color={COLOR.SECONDARY} />}
       onClose={onDismiss}
-      message={
-        <Flex gap={8} align="center">
-          <span style={{ fontWeight: 500 }}>Withdrawal failed</span>
-          {positionsStuck > 0 && (
-            <Text style={{ color: COLOR.SECONDARY, fontSize: 14 }}>
-              {positionsStuck} {positionsStuck === 1 ? 'position' : 'positions'} stuck
-            </Text>
-          )}
-        </Flex>
-      }
+      message={<span style={{ fontWeight: 500 }}>Withdrawal failed</span>}
     />
     <OpenPositionsValue amount={amount} />
     <InitiateButton onClick={onRetry} loading={isLoading} disabled={amount <= 0}>
@@ -253,7 +243,6 @@ export const WithdrawLockedFunds = ({ lockedAmount, marketName }: WithdrawLocked
           <ErrorBody
             amount={lockedAmount}
             isLoading={isLoading}
-            positionsStuck={data?.positions_stuck ?? 0}
             onRetry={handleInitiate}
             onDismiss={handleDismiss}
           />

--- a/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
+++ b/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
@@ -52,6 +52,17 @@ const ErrorAlert = styled(AntdAlert)`
   }
 `;
 
+const WarningAlert = styled(AntdAlert)`
+  background: ${COLOR.YELLOW_BACKGROUND};
+  border-color: ${COLOR.YELLOW_BACKGROUND};
+  align-items: flex-start;
+  padding: 16px;
+  .ant-alert-message,
+  .ant-alert-description {
+    color: ${COLOR.YELLOW};
+  }
+`;
+
 const Header = ({ marketName }: { marketName: string }) => (
   <Flex vertical gap={6}>
     <Title level={4} className="m-0 font-normal">
@@ -130,6 +141,35 @@ const DoneBody = ({ marketName, onDismiss }: { marketName: string; onDismiss: ()
   />
 );
 
+type PartialBodyProps = {
+  amount: number;
+  isLoading: boolean;
+  onRetry: () => void;
+  onDismiss: () => void;
+};
+
+const PartialBody = ({ amount, isLoading, onRetry, onDismiss }: PartialBodyProps) => (
+  <>
+    <WarningAlert
+      icon={<TriangleAlert size={16} color={COLOR.YELLOW} />}
+      showIcon
+      closable
+      closeIcon={<X size={16} color={COLOR.YELLOW} />}
+      onClose={onDismiss}
+      message={<span style={{ fontWeight: 500 }}>Partial withdrawal completed</span>}
+      description={
+        <span style={{ display: 'inline-block', maxWidth: 470 }}>
+          Some positions couldn&apos;t be sold. Please try again to withdraw the remaining funds.
+        </span>
+      }
+    />
+    <OpenPositionsValue amount={amount} />
+    <InitiateButton onClick={onRetry} loading={isLoading} disabled={amount <= 0}>
+      Initiate withdrawal
+    </InitiateButton>
+  </>
+);
+
 type ErrorBodyProps = {
   amount: number;
   isLoading: boolean;
@@ -190,10 +230,23 @@ export const WithdrawLockedFunds = ({ lockedAmount, marketName }: WithdrawLocked
 
   const renderBody = () => {
     const mode = data?.mode;
+    // A partial sweep ends in mode=errored but with at least one filled position.
+    // The UX is reframed as "completed with caveats" rather than a hard failure.
+    const isPartial = mode === 'errored' && (data?.fills.length ?? 0) > 0;
 
     if (!isResultDismissed) {
       if (mode === 'complete') {
         return <DoneBody marketName={marketName} onDismiss={handleDismiss} />;
+      }
+      if (isPartial) {
+        return (
+          <PartialBody
+            amount={lockedAmount}
+            isLoading={isLoading}
+            onRetry={handleInitiate}
+            onDismiss={handleDismiss}
+          />
+        );
       }
       if (mode === 'errored' || isError) {
         return (

--- a/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
+++ b/apps/predict-ui/src/components/WithdrawLockedFunds/WithdrawLockedFunds.tsx
@@ -1,0 +1,254 @@
+import { InfoCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { Alert as AntdAlert, Button, Flex, Spin, Tooltip, Typography } from 'antd';
+import { ExternalLink, Info, TriangleAlert, X } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { COLOR } from '../../constants/theme';
+import { useWithdrawLockedFunds } from '../../hooks/useWithdrawLockedFunds';
+import { Card } from '../ui/Card';
+
+const { Title, Text, Link } = Typography;
+
+const POSITIONS_TOOLTIP =
+  'Estimated value of all open positions at current market prices. Final value may differ at withdrawal.';
+
+const InitiateButton = styled(Button)`
+  align-self: flex-start;
+  height: auto;
+  padding: 8px 16px;
+  border-radius: 10px;
+  background: ${COLOR.WHITE_TRANSPARENT_10};
+  border-color: transparent;
+  color: ${COLOR.TEXT_PRIMARY};
+
+  &:hover,
+  &:focus {
+    background: ${COLOR.WHITE_TRANSPARENT_20} !important;
+    border-color: transparent !important;
+    color: ${COLOR.TEXT_PRIMARY} !important;
+  }
+`;
+
+const SuccessAlert = styled(AntdAlert)`
+  background: ${COLOR.GREEN_BACKGROUND};
+  border-color: ${COLOR.GREEN_BACKGROUND};
+  align-items: flex-start;
+  padding: 16px;
+  .ant-alert-message,
+  .ant-alert-description {
+    color: ${COLOR.GREEN};
+  }
+`;
+
+const ErrorAlert = styled(AntdAlert)`
+  background: ${COLOR.RED_BACKGROUND};
+  border-color: ${COLOR.RED_BACKGROUND};
+  align-items: center;
+  padding: 12px 16px;
+  .ant-alert-message {
+    color: ${COLOR.RED};
+    margin-bottom: 0;
+  }
+`;
+
+const Header = ({ marketName }: { marketName: string }) => (
+  <Flex vertical gap={6}>
+    <Title level={4} className="m-0 font-normal">
+      Withdraw funds locked in markets
+    </Title>
+    <Text type="secondary">
+      Closes all open positions on {marketName} and returns the funds to your agent wallet. Required
+      to fully withdraw your funds from the agent.
+    </Text>
+  </Flex>
+);
+
+const OpenPositionsValue = ({ amount }: { amount: number }) => (
+  <Flex vertical gap={6}>
+    <Flex align="center" gap={6}>
+      <Text type="secondary">Open positions value</Text>
+      <Tooltip title={POSITIONS_TOOLTIP}>
+        <InfoCircleOutlined style={{ color: COLOR.SECONDARY }} />
+      </Tooltip>
+    </Flex>
+    <Title level={4} className="m-0 font-normal">
+      ~${amount.toFixed(2)}
+    </Title>
+  </Flex>
+);
+
+type InitiateProps = {
+  amount: number;
+  isLoading: boolean;
+  onInitiate: () => void;
+};
+
+const InitiateBody = ({ amount, isLoading, onInitiate }: InitiateProps) => (
+  <>
+    <OpenPositionsValue amount={amount} />
+    <InitiateButton onClick={onInitiate} loading={isLoading}>
+      Initiate withdrawal
+    </InitiateButton>
+  </>
+);
+
+const SellingBody = ({ amount, message }: { amount: number; message: string }) => (
+  <>
+    <OpenPositionsValue amount={amount} />
+    <Flex gap={8} align="center">
+      <Spin indicator={<LoadingOutlined spin style={{ color: COLOR.TEXT_PRIMARY }} />} />
+      <Text type="secondary">{message}</Text>
+    </Flex>
+  </>
+);
+
+type DoneBodyProps = {
+  marketName: string;
+  transactionLink: string | null;
+  onDismiss: () => void;
+};
+
+const DoneBody = ({ marketName, transactionLink, onDismiss }: DoneBodyProps) => (
+  <SuccessAlert
+    icon={<Info size={16} color={COLOR.GREEN} />}
+    showIcon
+    closable
+    closeIcon={<X size={16} color={COLOR.GREEN} />}
+    onClose={onDismiss}
+    message={<span style={{ fontWeight: 500 }}>Withdrawal complete!</span>}
+    description={
+      <Flex vertical gap={8} style={{ maxWidth: 470 }}>
+        <span>
+          {marketName} positions have been sold, and funds are now in your Agent Wallet in Pearl.
+          The agent has stopped trading and will continue when restarted.
+        </span>
+        {transactionLink && (
+          <Link
+            href={transactionLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: COLOR.SECONDARY,
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 14,
+            }}
+          >
+            View transaction details
+            <ExternalLink size={14} />
+          </Link>
+        )}
+      </Flex>
+    }
+  />
+);
+
+type ErrorBodyProps = {
+  amount: number;
+  isLoading: boolean;
+  transactionLink: string | null;
+  onRetry: () => void;
+  onDismiss: () => void;
+};
+
+const ErrorBody = ({ amount, isLoading, transactionLink, onRetry, onDismiss }: ErrorBodyProps) => (
+  <>
+    <ErrorAlert
+      icon={<TriangleAlert size={16} color={COLOR.RED} />}
+      showIcon
+      closable
+      closeIcon={<X size={16} color={COLOR.SECONDARY} />}
+      onClose={onDismiss}
+      message={
+        <Flex gap={8} align="center">
+          <span style={{ fontWeight: 500 }}>Withdrawal failed</span>
+          {transactionLink && (
+            <Link
+              href={transactionLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: COLOR.SECONDARY,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              <span style={{ fontSize: 14 }}>Last transaction details</span>
+              <ExternalLink size={14} />
+            </Link>
+          )}
+        </Flex>
+      }
+    />
+    <OpenPositionsValue amount={amount} />
+    <InitiateButton onClick={onRetry} loading={isLoading}>
+      Initiate withdrawal
+    </InitiateButton>
+  </>
+);
+
+type WithdrawLockedFundsProps = {
+  /** Estimated USD value of currently locked positions. */
+  lockedAmount: number;
+  /** Display name of the prediction market the agent trades on (e.g. "Polymarket"). */
+  marketName: string;
+};
+
+export const WithdrawLockedFunds = ({ lockedAmount, marketName }: WithdrawLockedFundsProps) => {
+  const { isLoading, isError, data, initiateWithdraw } = useWithdrawLockedFunds();
+  const [isResultDismissed, setIsResultDismissed] = useState(false);
+
+  const handleInitiate = useCallback(async () => {
+    setIsResultDismissed(false);
+    try {
+      await initiateWithdraw();
+    } catch {
+      // surfaced via isError; intentionally swallowed to keep the UI in error state
+    }
+  }, [initiateWithdraw]);
+
+  const handleDismiss = useCallback(() => {
+    setIsResultDismissed(true);
+  }, []);
+
+  const status = data?.status;
+
+  const renderBody = () => {
+    if (!isResultDismissed) {
+      if (status === 'completed') {
+        return (
+          <DoneBody
+            marketName={marketName}
+            transactionLink={data?.transaction_link ?? null}
+            onDismiss={handleDismiss}
+          />
+        );
+      }
+      if (status === 'failed' || isError) {
+        return (
+          <ErrorBody
+            amount={lockedAmount}
+            isLoading={isLoading}
+            transactionLink={data?.transaction_link ?? null}
+            onRetry={handleInitiate}
+            onDismiss={handleDismiss}
+          />
+        );
+      }
+    }
+    if (status === 'initiated' || status === 'withdrawing') {
+      return <SellingBody amount={lockedAmount} message={data?.message ?? ''} />;
+    }
+    return <InitiateBody amount={lockedAmount} isLoading={isLoading} onInitiate={handleInitiate} />;
+  };
+
+  return (
+    <Card $gap="24px">
+      <Header marketName={marketName} />
+      {renderBody()}
+    </Card>
+  );
+};

--- a/apps/predict-ui/src/components/WithdrawLockedFunds/index.ts
+++ b/apps/predict-ui/src/components/WithdrawLockedFunds/index.ts
@@ -1,0 +1,1 @@
+export { WithdrawLockedFunds } from './WithdrawLockedFunds';

--- a/apps/predict-ui/src/constants/reactQueryKeys.ts
+++ b/apps/predict-ui/src/constants/reactQueryKeys.ts
@@ -5,4 +5,6 @@ export const REACT_QUERY_KEYS = {
   PROFIT_OVER_TIME: 'profitOverTime' as const,
   PREDICTION_HISTORY: 'predictionHistory' as const,
   PREDICTION_DETAILS: 'predictionDetails' as const,
+  WITHDRAW_INITIATE: 'withdrawInitiate' as const,
+  WITHDRAW_STATUS: 'withdrawStatus' as const,
 } as const;

--- a/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
+++ b/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
@@ -1,69 +1,63 @@
-import { LOCAL } from '@agent-ui-monorepo/util-constants-and-types';
+import { API_V1 } from '@agent-ui-monorepo/util-constants-and-types';
 import { delay, devMock, exponentialBackoffDelay } from '@agent-ui-monorepo/util-functions';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { REACT_QUERY_KEYS } from '../constants/reactQueryKeys';
-import { mockWithdrawInitiateResponse, mockWithdrawStatusResponse } from '../mocks/mockWithdrawal';
-import { WithdrawalInitiateResponse, WithdrawalStatus } from '../types';
+import { mockWithdrawalStatus } from '../mocks/mockWithdrawal';
+import { WithdrawalMode, WithdrawalStatus } from '../types';
 
 const POLL_INTERVAL_MS = 2000;
 
-const isTerminalStatus = (status: WithdrawalStatus['status'] | undefined) =>
-  status === 'completed' || status === 'failed';
+const isPollingMode = (mode: WithdrawalMode | undefined) => mode === 'armed' || mode === 'selling';
 
-const initiateWithdrawal = async (): Promise<WithdrawalInitiateResponse> => {
-  const mock = devMock(() => delay(mockWithdrawInitiateResponse));
+const fetchWithdrawalStatus = async (): Promise<WithdrawalStatus> => {
+  const mock = devMock(() => delay(mockWithdrawalStatus));
   if (mock !== null) return mock;
 
-  const response = await fetch(`${LOCAL}/withdrawal/initiate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!response.ok) throw new Error('Failed to initiate withdrawal.');
-  return response.json();
-};
-
-const fetchWithdrawalStatus = async (id: string): Promise<WithdrawalStatus> => {
-  const mock = devMock(() => delay(mockWithdrawStatusResponse));
-  if (mock !== null) return mock;
-
-  const response = await fetch(`${LOCAL}/withdrawal/status/${id}`);
+  const response = await fetch(`${API_V1}/withdrawal`);
   if (!response.ok) throw new Error('Failed to fetch withdrawal status.');
   return response.json();
 };
 
-export const useWithdrawLockedFunds = () => {
-  const [withdrawId, setWithdrawId] = useState<string | null>(null);
+const armWithdrawal = async (): Promise<WithdrawalStatus> => {
+  const mock = devMock(() => delay(mockWithdrawalStatus));
+  if (mock !== null) return mock;
 
-  const {
-    isPending: isInitiating,
-    isError: isInitiateError,
-    mutateAsync,
-    reset: resetMutation,
-  } = useMutation<WithdrawalInitiateResponse>({
-    mutationKey: [REACT_QUERY_KEYS.WITHDRAW_INITIATE],
-    mutationFn: async () => {
-      const response = await initiateWithdrawal();
-      setWithdrawId(response.id);
-      return response;
-    },
-    onError: (error) => {
-      console.error('Error initiating withdrawal:', error);
-      setWithdrawId(null);
-    },
-  });
+  const response = await fetch(`${API_V1}/withdrawal`, { method: 'POST' });
+  if (!response.ok) throw new Error('Failed to arm withdrawal.');
+  return response.json();
+};
+
+export const useWithdrawLockedFunds = () => {
+  const queryClient = useQueryClient();
 
   const { data, isLoading: isStatusLoading } = useQuery<WithdrawalStatus>({
-    queryKey: [REACT_QUERY_KEYS.WITHDRAW_STATUS, withdrawId],
-    queryFn: () => fetchWithdrawalStatus(withdrawId as string),
-    enabled: !!withdrawId,
-    refetchInterval: ({ state }) =>
-      isTerminalStatus(state.data?.status) ? false : POLL_INTERVAL_MS,
+    queryKey: [REACT_QUERY_KEYS.WITHDRAW_STATUS],
+    queryFn: fetchWithdrawalStatus,
+    refetchInterval: ({ state }) => (isPollingMode(state.data?.mode) ? POLL_INTERVAL_MS : false),
     // Infinite retries keep transient network failures from surfacing as a hard error
     // — the status query has no terminal "errored" state from the UI's perspective.
     retry: Infinity,
     retryDelay: exponentialBackoffDelay,
+  });
+
+  const {
+    isPending: isArming,
+    isError: isArmError,
+    mutateAsync,
+    reset: resetMutation,
+  } = useMutation<WithdrawalStatus>({
+    mutationKey: [REACT_QUERY_KEYS.WITHDRAW_INITIATE],
+    mutationFn: async () => {
+      const response = await armWithdrawal();
+      // POST returns the full status — push it into the query cache so the UI
+      // reflects the new mode immediately without waiting for the next poll tick.
+      queryClient.setQueryData<WithdrawalStatus>([REACT_QUERY_KEYS.WITHDRAW_STATUS], response);
+      return response;
+    },
+    onError: (error) => {
+      console.error('Error arming withdrawal:', error);
+    },
   });
 
   const initiateWithdraw = async () => {
@@ -72,8 +66,8 @@ export const useWithdrawLockedFunds = () => {
   };
 
   return {
-    isLoading: isInitiating || isStatusLoading,
-    isError: isInitiateError,
+    isLoading: isArming || isStatusLoading,
+    isError: isArmError,
     data,
     initiateWithdraw,
   };

--- a/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
+++ b/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
@@ -1,7 +1,7 @@
 import { API_V1 } from '@agent-ui-monorepo/util-constants-and-types';
 import { delay, devMock, exponentialBackoffDelay } from '@agent-ui-monorepo/util-functions';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { REACT_QUERY_KEYS } from '../constants/reactQueryKeys';
 import { mockWithdrawalStatus } from '../mocks/mockWithdrawal';
@@ -69,6 +69,16 @@ export const useWithdrawLockedFunds = () => {
     resetMutation();
     await mutateAsync();
   }, [mutateAsync, resetMutation]);
+
+  // Once the sweep reaches a terminal mode, the agent's funds_locked_in_markets
+  // metric has changed — refetch the performance query so the "Open positions
+  // value" displayed by the card (and elsewhere) reflects the post-sweep balance.
+  const mode = data?.mode;
+  useEffect(() => {
+    if (mode === 'complete' || mode === 'errored') {
+      queryClient.refetchQueries({ queryKey: [REACT_QUERY_KEYS.PERFORMANCE] });
+    }
+  }, [mode, queryClient]);
 
   return {
     isLoading: isArming,

--- a/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
+++ b/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
@@ -1,7 +1,7 @@
 import { API_V1 } from '@agent-ui-monorepo/util-constants-and-types';
 import { delay, devMock, exponentialBackoffDelay } from '@agent-ui-monorepo/util-functions';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { REACT_QUERY_KEYS } from '../constants/reactQueryKeys';
 import { mockWithdrawalStatus } from '../mocks/mockWithdrawal';
@@ -65,10 +65,10 @@ export const useWithdrawLockedFunds = () => {
     },
   });
 
-  const initiateWithdraw = async () => {
+  const initiateWithdraw = useCallback(async () => {
     resetMutation();
     await mutateAsync();
-  };
+  }, [mutateAsync, resetMutation]);
 
   return {
     isLoading: isArming,

--- a/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
+++ b/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
@@ -1,0 +1,80 @@
+import { LOCAL } from '@agent-ui-monorepo/util-constants-and-types';
+import { delay, devMock, exponentialBackoffDelay } from '@agent-ui-monorepo/util-functions';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { REACT_QUERY_KEYS } from '../constants/reactQueryKeys';
+import { mockWithdrawInitiateResponse, mockWithdrawStatusResponse } from '../mocks/mockWithdrawal';
+import { WithdrawalInitiateResponse, WithdrawalStatus } from '../types';
+
+const POLL_INTERVAL_MS = 2000;
+
+const isTerminalStatus = (status: WithdrawalStatus['status'] | undefined) =>
+  status === 'completed' || status === 'failed';
+
+const initiateWithdrawal = async (): Promise<WithdrawalInitiateResponse> => {
+  const mock = devMock(() => delay(mockWithdrawInitiateResponse));
+  if (mock !== null) return mock;
+
+  const response = await fetch(`${LOCAL}/withdrawal/initiate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!response.ok) throw new Error('Failed to initiate withdrawal.');
+  return response.json();
+};
+
+const fetchWithdrawalStatus = async (id: string): Promise<WithdrawalStatus> => {
+  const mock = devMock(() => delay(mockWithdrawStatusResponse));
+  if (mock !== null) return mock;
+
+  const response = await fetch(`${LOCAL}/withdrawal/status/${id}`);
+  if (!response.ok) throw new Error('Failed to fetch withdrawal status.');
+  return response.json();
+};
+
+export const useWithdrawLockedFunds = () => {
+  const [withdrawId, setWithdrawId] = useState<string | null>(null);
+
+  const {
+    isPending: isInitiating,
+    isError: isInitiateError,
+    mutateAsync,
+    reset: resetMutation,
+  } = useMutation<WithdrawalInitiateResponse>({
+    mutationKey: [REACT_QUERY_KEYS.WITHDRAW_INITIATE],
+    mutationFn: async () => {
+      const response = await initiateWithdrawal();
+      setWithdrawId(response.id);
+      return response;
+    },
+    onError: (error) => {
+      console.error('Error initiating withdrawal:', error);
+      setWithdrawId(null);
+    },
+  });
+
+  const { data, isLoading: isStatusLoading } = useQuery<WithdrawalStatus>({
+    queryKey: [REACT_QUERY_KEYS.WITHDRAW_STATUS, withdrawId],
+    queryFn: () => fetchWithdrawalStatus(withdrawId as string),
+    enabled: !!withdrawId,
+    refetchInterval: ({ state }) =>
+      isTerminalStatus(state.data?.status) ? false : POLL_INTERVAL_MS,
+    // Infinite retries keep transient network failures from surfacing as a hard error
+    // — the status query has no terminal "errored" state from the UI's perspective.
+    retry: Infinity,
+    retryDelay: exponentialBackoffDelay,
+  });
+
+  const initiateWithdraw = async () => {
+    resetMutation();
+    await mutateAsync();
+  };
+
+  return {
+    isLoading: isInitiating || isStatusLoading,
+    isError: isInitiateError,
+    data,
+    initiateWithdraw,
+  };
+};

--- a/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
+++ b/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
@@ -31,7 +31,7 @@ const armWithdrawal = async (): Promise<WithdrawalStatus> => {
 export const useWithdrawLockedFunds = () => {
   const queryClient = useQueryClient();
 
-  const { data, isLoading: isStatusLoading } = useQuery<WithdrawalStatus>({
+  const { data } = useQuery<WithdrawalStatus>({
     queryKey: [REACT_QUERY_KEYS.WITHDRAW_STATUS],
     queryFn: fetchWithdrawalStatus,
     refetchInterval: ({ state }) => (isPollingMode(state.data?.mode) ? POLL_INTERVAL_MS : false),
@@ -66,7 +66,10 @@ export const useWithdrawLockedFunds = () => {
   };
 
   return {
-    isLoading: isArming || isStatusLoading,
+    // POST-mutation only — drives the initiate button's loading state.
+    // The status GET is intentionally not surfaced here so the button doesn't
+    // flash "loading" while the initial status fetch is in flight.
+    isLoading: isArming,
     isError: isArmError,
     data,
     initiateWithdraw,

--- a/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
+++ b/apps/predict-ui/src/hooks/useWithdrawLockedFunds.ts
@@ -1,6 +1,7 @@
 import { API_V1 } from '@agent-ui-monorepo/util-constants-and-types';
 import { delay, devMock, exponentialBackoffDelay } from '@agent-ui-monorepo/util-functions';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { REACT_QUERY_KEYS } from '../constants/reactQueryKeys';
 import { mockWithdrawalStatus } from '../mocks/mockWithdrawal';
@@ -30,10 +31,14 @@ const armWithdrawal = async (): Promise<WithdrawalStatus> => {
 
 export const useWithdrawLockedFunds = () => {
   const queryClient = useQueryClient();
+  // Status polling is opt-in — only enabled after the user explicitly clicks
+  // "Initiate withdrawal". Until then, the page does not hit the withdrawal API.
+  const [hasArmed, setHasArmed] = useState(false);
 
   const { data } = useQuery<WithdrawalStatus>({
     queryKey: [REACT_QUERY_KEYS.WITHDRAW_STATUS],
     queryFn: fetchWithdrawalStatus,
+    enabled: hasArmed,
     refetchInterval: ({ state }) => (isPollingMode(state.data?.mode) ? POLL_INTERVAL_MS : false),
     // Infinite retries keep transient network failures from surfacing as a hard error
     // — the status query has no terminal "errored" state from the UI's perspective.
@@ -48,12 +53,12 @@ export const useWithdrawLockedFunds = () => {
     reset: resetMutation,
   } = useMutation<WithdrawalStatus>({
     mutationKey: [REACT_QUERY_KEYS.WITHDRAW_INITIATE],
-    mutationFn: async () => {
-      const response = await armWithdrawal();
+    mutationFn: armWithdrawal,
+    onSuccess: (response) => {
       // POST returns the full status — push it into the query cache so the UI
       // reflects the new mode immediately without waiting for the next poll tick.
       queryClient.setQueryData<WithdrawalStatus>([REACT_QUERY_KEYS.WITHDRAW_STATUS], response);
-      return response;
+      setHasArmed(true);
     },
     onError: (error) => {
       console.error('Error arming withdrawal:', error);
@@ -66,9 +71,6 @@ export const useWithdrawLockedFunds = () => {
   };
 
   return {
-    // POST-mutation only — drives the initiate button's loading state.
-    // The status GET is intentionally not surfaced here so the button doesn't
-    // flash "loading" while the initial status fetch is in flight.
     isLoading: isArming,
     isError: isArmError,
     data,

--- a/apps/predict-ui/src/mocks/mockWithdrawal.ts
+++ b/apps/predict-ui/src/mocks/mockWithdrawal.ts
@@ -1,11 +1,11 @@
 import { WithdrawalStatus } from '../types';
 
 export const mockWithdrawalStatus: WithdrawalStatus = {
-  mode: 'idle',
+  mode: 'errored',
   venue: 'polymarket',
-  positions_total: 0,
-  positions_sold: 0,
-  positions_stuck: 0,
+  positions_total: 7,
+  positions_sold: 5,
+  positions_stuck: 2,
   fills: [],
   errors: [],
 };

--- a/apps/predict-ui/src/mocks/mockWithdrawal.ts
+++ b/apps/predict-ui/src/mocks/mockWithdrawal.ts
@@ -1,7 +1,7 @@
 import { WithdrawalStatus } from '../types';
 
 export const mockWithdrawalStatus: WithdrawalStatus = {
-  mode: 'armed',
+  mode: 'idle',
   venue: 'polymarket',
   positions_total: 0,
   positions_sold: 0,

--- a/apps/predict-ui/src/mocks/mockWithdrawal.ts
+++ b/apps/predict-ui/src/mocks/mockWithdrawal.ts
@@ -1,0 +1,12 @@
+import { WithdrawalInitiateResponse, WithdrawalStatus } from '../types';
+
+export const mockWithdrawInitiateResponse: WithdrawalInitiateResponse = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  status: 'completed',
+} as const;
+
+export const mockWithdrawStatusResponse: WithdrawalStatus = {
+  status: 'completed',
+  message: 'Withdrawal completed successfully.',
+  transaction_link: 'https://etherscan.io/tx/0x1234567890abcdef',
+} as const;

--- a/apps/predict-ui/src/mocks/mockWithdrawal.ts
+++ b/apps/predict-ui/src/mocks/mockWithdrawal.ts
@@ -1,11 +1,11 @@
 import { WithdrawalStatus } from '../types';
 
 export const mockWithdrawalStatus: WithdrawalStatus = {
-  mode: 'errored',
+  mode: 'armed',
   venue: 'polymarket',
-  positions_total: 7,
-  positions_sold: 5,
-  positions_stuck: 2,
+  positions_total: 0,
+  positions_sold: 0,
+  positions_stuck: 0,
   fills: [],
   errors: [],
 };

--- a/apps/predict-ui/src/mocks/mockWithdrawal.ts
+++ b/apps/predict-ui/src/mocks/mockWithdrawal.ts
@@ -1,12 +1,11 @@
-import { WithdrawalInitiateResponse, WithdrawalStatus } from '../types';
+import { WithdrawalStatus } from '../types';
 
-export const mockWithdrawInitiateResponse: WithdrawalInitiateResponse = {
-  id: '550e8400-e29b-41d4-a716-446655440000',
-  status: 'completed',
-} as const;
-
-export const mockWithdrawStatusResponse: WithdrawalStatus = {
-  status: 'completed',
-  message: 'Withdrawal completed successfully.',
-  transaction_link: 'https://etherscan.io/tx/0x1234567890abcdef',
-} as const;
+export const mockWithdrawalStatus: WithdrawalStatus = {
+  mode: 'idle',
+  venue: 'polymarket',
+  positions_total: 0,
+  positions_sold: 0,
+  positions_stuck: 0,
+  fills: [],
+  errors: [],
+};

--- a/apps/predict-ui/src/types.ts
+++ b/apps/predict-ui/src/types.ts
@@ -134,16 +134,30 @@ export type AgentProfitTimeseriesResponse = {
   points: AgentProfitPoint[];
 };
 
-export type WithdrawalStatusValue = 'initiated' | 'withdrawing' | 'completed' | 'failed';
+export type WithdrawalMode = 'idle' | 'armed' | 'selling' | 'complete' | 'errored';
 
-export type WithdrawalInitiateResponse = {
-  id: string;
-  status: WithdrawalStatusValue;
+export type WithdrawalVenue = 'polymarket' | 'omen';
+
+export type WithdrawalFill = {
+  token_id: string;
+  shares_sold: number;
+  fill_price: number;
+  ts: number;
+};
+
+export type WithdrawalErrorRecord = {
+  token_id: string;
+  shares_remaining: number;
+  reason: string;
+  ts: number;
 };
 
 export type WithdrawalStatus = {
-  status: WithdrawalStatusValue;
-  /** human-readable status text rendered as-is during in-progress states */
-  message: string;
-  transaction_link: string | null;
+  mode: WithdrawalMode;
+  venue: WithdrawalVenue;
+  positions_total: number;
+  positions_sold: number;
+  positions_stuck: number;
+  fills: WithdrawalFill[];
+  errors: WithdrawalErrorRecord[];
 };

--- a/apps/predict-ui/src/types.ts
+++ b/apps/predict-ui/src/types.ts
@@ -133,3 +133,17 @@ export type AgentProfitTimeseriesResponse = {
   window: AgentWindow;
   points: AgentProfitPoint[];
 };
+
+export type WithdrawalStatusValue = 'initiated' | 'withdrawing' | 'completed' | 'failed';
+
+export type WithdrawalInitiateResponse = {
+  id: string;
+  status: WithdrawalStatusValue;
+};
+
+export type WithdrawalStatus = {
+  status: WithdrawalStatusValue;
+  /** human-readable status text rendered as-is during in-progress states */
+  message: string;
+  transaction_link: string | null;
+};


### PR DESCRIPTION
## Summary

- Adds a Polystrat-only "Withdraw funds locked in markets" card to predict-ui that closes all open Polymarket positions and returns the funds to the agent wallet.
- Card sits below the Chat panel, gated by `isPolystratAgent` so Omenstrat continues to render unchanged.
- Backend contract mirrors babydegen (`POST {LOCAL}/withdrawal/initiate` → id; `GET {LOCAL}/withdrawal/status/{id}` polled every 2s; halts on `completed`/`failed`).

## Implementation notes

- `useWithdrawLockedFunds` hook: `useMutation` for initiate + polled `useQuery` for status with `retry: Infinity` + `exponentialBackoffDelay` so transient network errors don't surface as a hard fail.
- The component renders four states from figma — initial, in-progress, done (green alert + dismissable + tx link), error (red compact alert + retry below) — driven off `data.status` and a local `isResultDismissed` flag.
- `marketName` prop is wired through Header and DoneBody so the same component works for Omenstrat once its backend is ready (just flip the gate in `agent.tsx` and pass `"Omen"`).
- Status `message` text for the in-progress state comes from the backend response and is rendered as-is.

## Test plan

- [ ] Set `REACT_APP_AGENT_NAME=polystrat_trader` + `IS_MOCK_ENABLED=true`, run `yarn nx dev predict-ui`, scroll to bottom of the page.
- [ ] Initial state shows `~$120.32` and the "Initiate withdrawal" button.
- [ ] Click *Initiate withdrawal* → spinner + "Withdrawal initiated. Selling open positions..." (no UI freeze, no double-fire).
- [ ] Edit `mockWithdrawal.ts` → `status: 'completed'` + a tx link → reload, click Initiate → green "Withdrawal complete!" alert with working tx link, dismiss X falls back to initial body.
- [ ] Edit `mockWithdrawal.ts` → `status: 'failed'` + tx link → reload, click Initiate → red "Withdrawal failed" alert above the initiate body, retry from the button works, dismiss X removes the alert and leaves the initiate body.
- [ ] Confirm Omenstrat still renders identically (set `REACT_APP_AGENT_NAME=omenstrat_trader`, no card visible).
- [ ] `yarn nx test predict-ui` passes (4 new spec files, 27 added tests).
- [ ] `yarn nx lint predict-ui` clean.
- [ ] `yarn nx build predict-ui` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)