### PR TITLE
feat: enable withdraw locked funds card for omenstrat

### DIFF
--- a/apps/predict-ui/src/app/agent.tsx
+++ b/apps/predict-ui/src/app/agent.tsx
@@ -115,12 +115,10 @@ export const Agent = () => {
         <TradeHistory />
         <Strategy />
         <ChatContent />
-        {isPolystratAgent && (
-          <WithdrawLockedFunds
-            lockedAmount={performance.metrics.funds_locked_in_markets}
-            marketName="Polymarket"
-          />
-        )}
+        <WithdrawLockedFunds
+          lockedAmount={performance.metrics.funds_locked_in_markets}
+          marketName={isPolystratAgent ? 'Polymarket' : 'Omen'}
+        />
       </AgentContent>
     </Flex>
   );


### PR DESCRIPTION
## Summary
- Removes the polystrat-only gate on the `WithdrawLockedFunds` card so it also renders on the Omenstrat UI
- Market name is picked per agent: `Polymarket` for polystrat, `Omen` for omenstrat
- No backend changes needed — `WithdrawalVenue` already supports `'polymarket' | 'omen'`

Resolves [OPE-1678](https://linear.app/valory-xyz/issue/OPE-1678).

Note: the Pearl wallet decommission alert mentioned in the issue lives in a separate repo and is out of scope for this PR.

## Test plan
- [ ] `REACT_APP_AGENT_NAME=omenstrat_trader yarn nx dev predict-ui` — withdraw card appears with header "Withdraw funds locked in markets" and copy referencing "Omen"
- [ ] `REACT_APP_AGENT_NAME=polystrat_trader yarn nx dev predict-ui` — copy still references "Polymarket"
- [ ] Initiate withdrawal flow (initial → armed/selling → complete / errored / partial) renders correctly for omenstrat
- [ ] `yarn nx test predict-ui` passes (241 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)