### PR TITLE
feat(predict-ui): add Polymarket incomplete-data alert for polystrat

### DIFF
--- a/apps/predict-ui/__tests__/app/agent.polystrat.spec.tsx
+++ b/apps/predict-ui/__tests__/app/agent.polystrat.spec.tsx
@@ -1,0 +1,68 @@
+// Mock agentMap to simulate polystrat environment (isPolystratAgent=true)
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+
+import { Agent } from '../../src/app/agent';
+import { useAgentDetails } from '../../src/hooks/useAgentDetails';
+import { useFeatures } from '../../src/hooks/useFeatures';
+
+jest.mock('../../src/utils/agentMap', () => ({
+  agentType: 'polystrat_trader',
+  isOmenstratAgent: false,
+  isPolystratAgent: true,
+}));
+
+jest.mock('../../src/hooks/useAgentDetails');
+jest.mock('../../src/hooks/useFeatures');
+jest.mock('../../src/components/Chat/Chat', () => ({
+  Chat: () => <div data-testid="chat-mock">Chat</div>,
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+const mockAgentDetails = {
+  id: '0xabc',
+  created_at: '2024-01-01T00:00:00Z',
+  last_active_at: '2024-06-01T00:00:00Z',
+};
+
+const mockPerformance = {
+  agent_id: '0xabc',
+  window: 'lifetime',
+  currency: 'USD',
+  metrics: {
+    all_time_funds_used: 20,
+    all_time_profit: 2,
+    funds_locked_in_markets: 0.1,
+    available_funds: 10,
+    roi: 0.1,
+  },
+  stats: { predictions_made: 100, prediction_accuracy: 0.5 },
+};
+
+describe('Agent – polystrat agent (isPolystratAgent=true)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useFeatures as jest.Mock).mockReturnValue({
+      isLoading: false,
+      data: { isChatEnabled: false },
+    });
+  });
+
+  it('renders the incomplete-data alert when data is available', () => {
+    (useAgentDetails as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { agentDetails: mockAgentDetails, performance: mockPerformance },
+    });
+    render(<Agent />, { wrapper: createWrapper() });
+    expect(screen.getByText('Some performance data may be incomplete')).toBeInTheDocument();
+  });
+});

--- a/apps/predict-ui/__tests__/app/agent.spec.tsx
+++ b/apps/predict-ui/__tests__/app/agent.spec.tsx
@@ -89,6 +89,16 @@ describe('Agent', () => {
     expect(screen.getByText('Performance')).toBeInTheDocument();
   });
 
+  it('does not render the incomplete-data alert for omenstrat agent', () => {
+    (useAgentDetails as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { agentDetails: mockAgentDetails, performance: mockPerformance },
+    });
+    render(<Agent />, { wrapper: createWrapper() });
+    expect(screen.queryByText('Some performance data may be incomplete')).toBeNull();
+  });
+
   it('renders UnlockChat when isChatEnabled=false and features loaded', () => {
     (useAgentDetails as jest.Mock).mockReturnValue({
       isLoading: false,

--- a/apps/predict-ui/src/app/agent.tsx
+++ b/apps/predict-ui/src/app/agent.tsx
@@ -10,6 +10,7 @@ import { AgentPerformance } from '../components/Performance';
 import { ProfitOverTime } from '../components/ProfitOverTime/ProfitOverTime';
 import { Strategy } from '../components/Strategy';
 import { TradeHistory } from '../components/TradeHistory/TradeHistory';
+import { Alert } from '../components/ui/Alert';
 import { Card } from '../components/ui/Card';
 import { WithdrawLockedFunds } from '../components/WithdrawLockedFunds';
 import { COLOR } from '../constants/theme';
@@ -78,6 +79,14 @@ const AgentNotFound = () => (
   </Flex>
 );
 
+const IncompleteDataAlert = () => (
+  <Alert
+    type="warning"
+    message="Some performance data may be incomplete"
+    description="After a recent Polymarket protocol upgrade, some winning payouts after Apr 28 may not be reflected in performance metrics or Trade history yet. Your agent is still running normally, and missing data will appear once indexing catches up."
+  />
+);
+
 const ChatContent = () => {
   const { isLoading, data } = useFeatures();
 
@@ -110,6 +119,7 @@ export const Agent = () => {
           createdAt={agentDetails.created_at}
           lastActiveAt={agentDetails.last_active_at}
         />
+        {isPolystratAgent && <IncompleteDataAlert />}
         <AgentPerformance performance={performance} />
         <ProfitOverTime />
         <TradeHistory />


### PR DESCRIPTION
## What

Adds the Polymarket-specific warning banner from the [Figma design](https://www.figma.com/design/HB1eVqbkaFRYs6NXbUmuQM/Pearl-1.0?node-id=24412-11869) to the predict-ui agent page. Every other element in that design already existed — this banner is the only new piece.

The banner reuses the existing `Alert` component (`type="warning"`) and is rendered between the meta-info card and the Performance card, matching the design. It is gated on `isPolystratAgent`, so it renders only for `polystrat_trader` (Polymarket) and never for omenstrat.

<img width="818" height="396" alt="Screenshot 2026-06-01 at 4 40 29 PM" src="https://github.com/user-attachments/assets/8c3e3751-5f36-4c44-8edc-422e75811f91" />


Copy (verbatim from design):

> **Some performance data may be incomplete** — After a recent Polymarket protocol upgrade, some winning payouts after Apr 28 may not be reflected in performance metrics or Trade history yet. Your agent is still running normally, and missing data will appear once indexing catches up.

## Tests

- `agent.spec.tsx`: asserts the banner is **not** shown for the default omenstrat agent.
- `agent.polystrat.spec.tsx` (new, follows the `.polystrat.spec.tsx` convention): mocks `agentMap` to polystrat and asserts the banner **is** shown.

All 243 predict-ui tests pass; coverage held at 100%; lint clean.

## Open question

The banner is implemented as a permanent static notice exactly as drawn. If it's meant to be temporary or data-driven (dismissable, or gated on an API/feature flag), say so and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)