### PR TITLE
feat(release): scope GitHub release notes to each app's code

### DIFF
--- a/.github/workflows/_build-app.yml
+++ b/.github/workflows/_build-app.yml
@@ -64,16 +64,17 @@ jobs:
             echo "_Manual build of \`${{ inputs.app-name }}\` (${GITHUB_REF_NAME})._" > RELEASE_NOTES.md
           else
             TAG="${GITHUB_REF_NAME}"
+            # The release line is the tag's market suffix (e.g. omenstrat-trader).
             SUFFIX="$(printf '%s' "$TAG" | sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+//; s/^-//')"
-            if [ -n "$SUFFIX" ]; then
-              PREV="$(git tag --sort=-creatordate -l "v*-$SUFFIX" | grep -vxF "$TAG" | head -n1 || true)"
-            else
-              PREV="$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
-            fi
-            echo "Scoping ${{ inputs.app-name }} notes: ${PREV:-<first release>}..$TAG"
-            FROM_ARG=""
-            [ -n "$PREV" ] && FROM_ARG="--from $PREV"
-            node scripts/release-notes.mjs --project "${{ inputs.app-name }}" $FROM_ARG --to "$TAG" > RELEASE_NOTES.md
+            if [ -n "$SUFFIX" ]; then PATTERN="v*-$SUFFIX"; else PATTERN="$TAG"; fi
+            # Exclude EVERY prior tag on this line, not just the "previous" one:
+            # these are lightweight tags whose version order is not monotonic
+            # with commit date, so no single-predecessor sort is reliable. The
+            # notes then list only commits not already shipped in any release.
+            PRIORS="$(git tag -l "$PATTERN" | grep -vxF "$TAG" || true)"
+            echo "Scoping ${{ inputs.app-name }} notes for $TAG; excluding prior $PATTERN releases:"
+            printf '%s\n' "$PRIORS" | sed 's/^/  - /'
+            node scripts/release-notes.mjs --project "${{ inputs.app-name }}" --to "$TAG" --not "$PRIORS" > RELEASE_NOTES.md
           fi
           echo "----- RELEASE_NOTES.md -----"
           cat RELEASE_NOTES.md

--- a/.github/workflows/_build-app.yml
+++ b/.github/workflows/_build-app.yml
@@ -25,11 +25,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # needed by softprops/action-gh-release to create the GitHub Release
+      contents: write # needed by softprops/action-gh-release to create the GitHub Release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          # Full history + tags are required to diff this tag against the
+          # previous same-line tag when generating scoped release notes.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
@@ -50,6 +54,30 @@ jobs:
         if: inputs.agent-env != ''
         run: echo "REACT_APP_AGENT_NAME=${{ inputs.agent-env }}" >> $GITHUB_ENV
 
+      - name: Generate scoped release notes
+        # Build notes containing only this app's (and its shared libs') commits,
+        # scoped via the Nx project graph — see scripts/release-notes.mjs. Falls
+        # back to a placeholder for non-tag (workflow_dispatch) runs.
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+            echo "_Manual build of \`${{ inputs.app-name }}\` (${GITHUB_REF_NAME})._" > RELEASE_NOTES.md
+          else
+            TAG="${GITHUB_REF_NAME}"
+            SUFFIX="$(printf '%s' "$TAG" | sed -E 's/^v[0-9]+\.[0-9]+\.[0-9]+//; s/^-//')"
+            if [ -n "$SUFFIX" ]; then
+              PREV="$(git tag --sort=-creatordate -l "v*-$SUFFIX" | grep -vxF "$TAG" | head -n1 || true)"
+            else
+              PREV="$(git describe --tags --abbrev=0 "$TAG^" 2>/dev/null || true)"
+            fi
+            echo "Scoping ${{ inputs.app-name }} notes: ${PREV:-<first release>}..$TAG"
+            FROM_ARG=""
+            [ -n "$PREV" ] && FROM_ARG="--from $PREV"
+            node scripts/release-notes.mjs --project "${{ inputs.app-name }}" $FROM_ARG --to "$TAG" > RELEASE_NOTES.md
+          fi
+          echo "----- RELEASE_NOTES.md -----"
+          cat RELEASE_NOTES.md
+
       - name: Build app
         run: yarn nx build ${{ inputs.app-name }}
 
@@ -64,6 +92,8 @@ jobs:
           files: ${{ inputs.app-name }}-build.zip
           name: Release ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
-          generate_release_notes: true
+          # Scoped notes generated above (replaces generate_release_notes, which
+          # listed every commit in the range regardless of which app it touched).
+          body_path: RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "7.28.5",
     "@babel/preset-react": "7.28.5",
     "@eslint/js": "9.39.2",
+    "@nx/devkit": "21.1.3",
     "@nx/eslint": "21.1.3",
     "@nx/eslint-plugin": "21.1.3",
     "@nx/jest": "21.1.3",

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -13,12 +13,18 @@
  * Usage:
  *   node scripts/release-notes.mjs \
  *     --project predict-ui \
- *     --from v0.1.14-omenstrat-trader \
  *     --to   v0.1.20-omenstrat-trader \
+ *     --not  "v0.1.19-omenstrat-trader v0.1.18-omenstrat-trader ..." \
  *     [--repo valory-xyz/agent-ui-monorepo]
  *
- * Prints Markdown to stdout. `--from` may be omitted for the first release
- * (history is then walked from the repo root up to `--to`).
+ * `--not` is a whitespace-separated list of every prior tag on the release
+ * line; the notes then contain only commits reachable from `--to` but from
+ * none of those tags — i.e. not already shipped. This is robust to tags whose
+ * version order does not match commit order (these are lightweight tags and
+ * are not monotonic). `--from <ref>` is also accepted for ad-hoc `from..to`
+ * ranges. With neither, history is walked from the repo root (first release).
+ *
+ * Prints Markdown to stdout.
  */
 import { execFileSync } from 'node:child_process';
 
@@ -34,7 +40,8 @@ const parseArgs = (argv) => {
   return out;
 };
 
-const git = (args) => execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
+const git = (args) =>
+  execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
 
 const resolveRepoSlug = (explicit) => {
   if (explicit) return explicit;
@@ -76,7 +83,13 @@ const classify = (subject) => {
 };
 
 const main = async () => {
-  const { project, from, to = 'HEAD', repo } = parseArgs(process.argv.slice(2));
+  const {
+    project,
+    from,
+    to = 'HEAD',
+    repo,
+    not,
+  } = parseArgs(process.argv.slice(2));
   if (!project) throw new Error('Missing required --project');
 
   const slug = resolveRepoSlug(repo);
@@ -84,8 +97,22 @@ const main = async () => {
   if (!graph.nodes[project]) throw new Error(`Unknown Nx project: ${project}`);
 
   const paths = collectProjectPaths(graph, project);
-  const range = from ? `${from}..${to}` : to;
-  const raw = git(['log', range, '--no-merges', '--pretty=format:%H%x1f%s', '--', ...paths]).trim();
+  const excludes = (not ?? '').split(/\s+/).filter(Boolean);
+  // Prefer excluding every prior tag (`--not`); fall back to an explicit
+  // `from..to` range, then to full history for a first release.
+  const revArgs = from
+    ? [`${from}..${to}`]
+    : excludes.length
+      ? [to, '--not', ...excludes]
+      : [to];
+  const raw = git([
+    'log',
+    '--no-merges',
+    '--pretty=format:%H%x1f%s',
+    ...revArgs,
+    '--',
+    ...paths,
+  ]).trim();
 
   /** @type {Record<string, string[]>} */
   const buckets = Object.fromEntries(SECTIONS.map((s) => [s.key, []]));
@@ -94,7 +121,9 @@ const main = async () => {
       const [hash, subject] = line.split('\x1f');
       const { type, text } = classify(subject);
       const short = hash.slice(0, 7);
-      buckets[type].push(`- ${text} ([${short}](https://github.com/${slug}/commit/${hash}))`);
+      buckets[type].push(
+        `- ${text} ([${short}](https://github.com/${slug}/commit/${hash}))`,
+      );
     }
   }
 
@@ -102,7 +131,9 @@ const main = async () => {
     .map((s) => `### ${s.title}\n\n${buckets[s.key].join('\n')}`)
     .join('\n\n');
 
-  process.stdout.write(body || `_No changes scoped to \`${project}\` in this release._\n`);
+  process.stdout.write(
+    body || `_No changes scoped to \`${project}\` in this release._\n`,
+  );
 };
 
 main().catch((error) => {

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,111 @@
+// @ts-check
+/**
+ * Generate release notes scoped to a single Nx project's code.
+ *
+ * `nx release changelog` (and GitHub's `generate_release_notes`) list every
+ * commit in the tag range regardless of which app it touched, so an
+ * omenstrat-trader release ends up showing babydegen / agentsfun / workspace
+ * commits. This script instead walks the Nx project graph to collect the
+ * project's own directory plus every workspace library it depends on, then runs
+ * `git log` restricted to those paths — so the notes contain only the agent's
+ * (and its shared libs') changes.
+ *
+ * Usage:
+ *   node scripts/release-notes.mjs \
+ *     --project predict-ui \
+ *     --from v0.1.14-omenstrat-trader \
+ *     --to   v0.1.20-omenstrat-trader \
+ *     [--repo valory-xyz/agent-ui-monorepo]
+ *
+ * Prints Markdown to stdout. `--from` may be omitted for the first release
+ * (history is then walked from the repo root up to `--to`).
+ */
+import { execFileSync } from 'node:child_process';
+
+import { createProjectGraphAsync } from '@nx/devkit';
+
+const parseArgs = (argv) => {
+  /** @type {Record<string, string>} */
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) out[arg.slice(2)] = argv[++i];
+  }
+  return out;
+};
+
+const git = (args) => execFileSync('git', args, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
+
+const resolveRepoSlug = (explicit) => {
+  if (explicit) return explicit;
+  const url = git(['config', '--get', 'remote.origin.url']).trim();
+  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/);
+  if (!match) throw new Error(`Cannot derive repo slug from remote: ${url}`);
+  return match[1];
+};
+
+/** Collect the project's root plus the roots of all workspace libs it depends on. */
+const collectProjectPaths = (graph, project) => {
+  const roots = new Set();
+  const visit = (name) => {
+    const node = graph.nodes[name];
+    if (!node || roots.has(node.data.root)) return;
+    roots.add(node.data.root);
+    for (const dep of graph.dependencies[name] ?? []) {
+      // Only follow workspace projects; ignore external (npm) dependencies.
+      if (graph.nodes[dep.target]) visit(dep.target);
+    }
+  };
+  visit(project);
+  return [...roots];
+};
+
+const SECTIONS = [
+  { key: 'feat', title: '🚀 Features' },
+  { key: 'fix', title: '🩹 Fixes' },
+  { key: 'perf', title: '⚡ Performance' },
+  { key: 'other', title: '🧱 Other Changes' },
+];
+
+const classify = (subject) => {
+  const match = subject.match(/^(\w+)(?:\([^)]*\))?!?:\s*(.+)$/);
+  if (!match) return { type: 'other', text: subject };
+  const type = match[1].toLowerCase();
+  const known = SECTIONS.some((s) => s.key === type);
+  return { type: known ? type : 'other', text: match[2] };
+};
+
+const main = async () => {
+  const { project, from, to = 'HEAD', repo } = parseArgs(process.argv.slice(2));
+  if (!project) throw new Error('Missing required --project');
+
+  const slug = resolveRepoSlug(repo);
+  const graph = await createProjectGraphAsync({ exitOnError: true });
+  if (!graph.nodes[project]) throw new Error(`Unknown Nx project: ${project}`);
+
+  const paths = collectProjectPaths(graph, project);
+  const range = from ? `${from}..${to}` : to;
+  const raw = git(['log', range, '--no-merges', '--pretty=format:%H%x1f%s', '--', ...paths]).trim();
+
+  /** @type {Record<string, string[]>} */
+  const buckets = Object.fromEntries(SECTIONS.map((s) => [s.key, []]));
+  if (raw) {
+    for (const line of raw.split('\n')) {
+      const [hash, subject] = line.split('\x1f');
+      const { type, text } = classify(subject);
+      const short = hash.slice(0, 7);
+      buckets[type].push(`- ${text} ([${short}](https://github.com/${slug}/commit/${hash}))`);
+    }
+  }
+
+  const body = SECTIONS.filter((s) => buckets[s.key].length)
+    .map((s) => `### ${s.title}\n\n${buckets[s.key].join('\n')}`)
+    .join('\n\n');
+
+  process.stdout.write(body || `_No changes scoped to \`${project}\` in this release._\n`);
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Each app publishes a per-market release (`v*-omenstrat-trader`, `v*-polystrat-trader`, `v*-modius`, `v*-optimus`, `v*-agentsfun`). The reusable `_build-app.yml` created those releases with `generate_release_notes: true`, which diffs against the previous tag chronologically and lists **every PR merged repo-wide** since then — with no path awareness. So an `omenstrat-trader` release showed commits that only touched `babydegen-ui`, `agentsfun-ui`, or root tooling.

Context: Pearl now surfaces each agent's UI version on its Release Notes page and links to these GitHub releases (Linear OPE-1709), so the notes being agent-scoped actually matters.

## Why not `nx release changelog`

We're on Nx 21, so the obvious move was `nx release changelog`. It **does not path-scope** over an explicit tag range — verified locally: scoping to `predict-ui` over `v0.1.14..v0.1.20-omenstrat-trader` still emitted `.claude` and `supply-chain` commits, and over an older range it emitted `ModiusUI` / babydegen commits. With a `--from/--to` range Nx includes the whole range and ignores the project graph. (It also wants to own tags/versions via `releaseTagPattern`, which doesn't fit our `v{ver}-{market}` scheme — and we want to keep that scheme since Pearl links to it.)

## Solution

Generate notes from the **Nx project graph + a scoped `git log`**:

1. `scripts/release-notes.mjs` walks the project graph for the released app, collecting its own directory **plus the roots of every workspace lib it depends on** (`util-functions`, `ui-theme`, …).
2. `git log <prevTag>..<thisTag> -- <those paths>` → only commits touching the app or its shared libs.
3. Conventional-commit subjects are grouped (Features / Fixes / Performance / Other) with commit links.

`_build-app.yml`:
- `fetch-depth: 0` so full tag history is available.
- New step computes the previous **same-line** tag (`v*-<suffix>`), runs the script → `RELEASE_NOTES.md` (placeholder for `workflow_dispatch` runs).
- `generate_release_notes: true` → `body_path: RELEASE_NOTES.md`.

## Scoping semantics

- ✅ App's own commits.
- ✅ Shared-lib commits (a `ui-theme` change correctly appears in every app that depends on it — dependency-aware, the whole point of using the graph).
- ❌ Other apps' exclusive commits.
- ❌ Root/tooling commits (`.github`, `.claude`, supply-chain) that touch no app or lib.

The two market variants of one app (omenstrat/polystrat off `predict-ui`; modius/optimus off `babydegen-ui`) share source, so they share scoped notes — only the tag range differs. Expected.

## Validation (local)

`predict-ui` over `v0.1.14..v0.1.20-omenstrat-trader`:
- before: included `.claude` + `supply-chain` root commits (via `nx release changelog`)
- after: only `predict-ui` + shared-lib commits; root noise gone; no `babydegen`/`agentsfun`-exclusive commits

## Notes for reviewers

- Draft — please sanity-check the previous-tag selection (`git tag --sort=-creatordate -l "v*-<suffix>"`) against how you cut tags, and confirm `@nx/devkit`'s `createProjectGraphAsync` runs clean in CI after `yarn install`.
- No change to the tag scheme, triggers, or build/zip steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)