### PR TITLE
fix: [BDMARK-2224] bump ws resolution to 8.21.0 for GHSA-96hv-2xvq-fx4p

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.7",
     "rollup": "4.60.4",
     "qs": "6.15.2",
-    "ws": "8.20.1",
+    "ws": "8.21.0",
     "koa": "2.16.4",
     "**/nx/minimatch": "9.0.9",
     "**/@nx/devkit/minimatch": "9.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13635,10 +13635,10 @@ write-file-atomic@^7.0.0:
   dependencies:
     signal-exit "^4.0.1"
 
-ws@8.18.0, ws@8.18.3, ws@8.20.1, ws@^8.11.0, ws@^8.13.0:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@8.18.0, ws@8.18.3, ws@8.21.0, ws@^8.11.0, ws@^8.13.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What & why

The weekly **Supply Chain** audit (`yarn audit:prod` → `scripts/audit.mjs`) has failed on `main` since **2026-06-22**:

```
[high] ws >=8.0.0 <8.21.0 → fix in >=8.21.0
  advisory 1120730 (GHSA-96hv-2xvq-fx4p)
  ws: Memory exhaustion DoS from tiny fragments and data chunks
  1 path(s), e.g. viem>ws
```

`ws` was already pinned via a root `resolutions` entry to `8.20.1` (from an earlier advisory). GHSA-96hv-2xvq-fx4p was published *after* that pin and requires `>=8.21.0`, so the existing pin fell back into the vulnerable range. This is unrelated to any feature branch — every branch inherits the failure from `main`.

## Change

Bump the resolution one patch:

```diff
-    "ws": "8.20.1",
+    "ws": "8.21.0",
```

plus the refreshed `yarn.lock` (`ws@…: version "8.21.0"`). Chose bump-the-pin over allowlisting in `.supply-chain/audit-allowlist.json` because a fixed release exists — matches the established pattern of that resolutions block.

## Testing

- ✅ `node scripts/audit.mjs` → `yarn audit: OK (0 allowlisted, no unlisted high/critical).`
- ✅ `nx test babydegen-ui` → 26 suites / 122 tests pass (no runtime regression from the bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
