### PR TITLE
chore: [VLOP-101] Update Connect UI transaction-mode and password-modal copy

### DIFF
--- a/apps/connect-ui/__tests__/App.spec.tsx
+++ b/apps/connect-ui/__tests__/App.spec.tsx
@@ -58,7 +58,8 @@ describe('App', () => {
     expect(screen.getByText('Coding tool')).toBeInTheDocument();
     expect(screen.getByText('Transaction mode')).toBeInTheDocument();
     expect(screen.getByText('Whitelisted addresses')).toBeInTheDocument();
-    expect(screen.getByText('0x735f...70bb')).toBeInTheDocument();
+    // Whitelist entries are deliberately not listed.
+    expect(screen.queryByText('0x735f...70bb')).not.toBeInTheDocument();
     expect(screen.queryByText('Unrestricted mode is on')).not.toBeInTheDocument();
   });
 

--- a/apps/connect-ui/__tests__/components/CodingTool.spec.tsx
+++ b/apps/connect-ui/__tests__/components/CodingTool.spec.tsx
@@ -57,6 +57,6 @@ describe('CodingTool', () => {
     expect(url).toContain('/settings');
     expect(init.method).toBe('PATCH');
     expect(JSON.parse(init.body)).toEqual({ harness: 'claude_code_cli' });
-    expect(screen.queryByText(/Enter password/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Enter your password/)).not.toBeInTheDocument();
   });
 });

--- a/apps/connect-ui/__tests__/components/TransactionMode.spec.tsx
+++ b/apps/connect-ui/__tests__/components/TransactionMode.spec.tsx
@@ -100,7 +100,7 @@ describe('TransactionMode', () => {
     fireEvent.click(screen.getByText('Unrestricted'));
     await screen.findByText('Switch to Unrestricted mode?');
 
-    fireEvent.change(screen.getByLabelText(/Enter password/), {
+    fireEvent.change(screen.getByLabelText(/Enter your password/), {
       target: { value: 'hunter2' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Switch to Unrestricted' }));
@@ -131,7 +131,7 @@ describe('TransactionMode', () => {
     fireEvent.click(screen.getByText('Unrestricted'));
     await screen.findByText('Switch to Unrestricted mode?');
 
-    fireEvent.change(screen.getByLabelText(/Enter password/), {
+    fireEvent.change(screen.getByLabelText(/Enter your password/), {
       target: { value: 'wrong' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Switch to Unrestricted' }));

--- a/apps/connect-ui/__tests__/components/WhitelistedAddresses.spec.tsx
+++ b/apps/connect-ui/__tests__/components/WhitelistedAddresses.spec.tsx
@@ -3,14 +3,18 @@ import { render, screen } from '@testing-library/react';
 import { WhitelistedAddresses } from '../../src/components/WhitelistedAddresses/WhitelistedAddresses';
 
 describe('WhitelistedAddresses', () => {
-  it('renders the section heading and description without listing addresses', () => {
+  it('describes the whitelisted destinations without listing raw addresses', () => {
     render(<WhitelistedAddresses />);
 
     expect(screen.getByText('Whitelisted addresses')).toBeInTheDocument();
     expect(
       screen.getByText('Specifies allowed web3 addresses your agent can interact with.'),
     ).toBeInTheDocument();
-    // The whitelist entries themselves are deliberately not rendered.
+    expect(screen.getByText('Olas Marketplace')).toBeInTheDocument();
+    expect(
+      screen.getByText('Connects your agent to the marketplace with various services.'),
+    ).toBeInTheDocument();
+    // Raw whitelist entries are deliberately not rendered.
     expect(screen.queryByText(/^0x/)).not.toBeInTheDocument();
     expect(screen.queryByText(/^Chain:/)).not.toBeInTheDocument();
   });

--- a/apps/connect-ui/__tests__/components/WhitelistedAddresses.spec.tsx
+++ b/apps/connect-ui/__tests__/components/WhitelistedAddresses.spec.tsx
@@ -3,35 +3,15 @@ import { render, screen } from '@testing-library/react';
 import { WhitelistedAddresses } from '../../src/components/WhitelistedAddresses/WhitelistedAddresses';
 
 describe('WhitelistedAddresses', () => {
-  it('renders each entry as a truncated address with its chain', () => {
-    render(
-      <WhitelistedAddresses
-        whitelist={{
-          gnosis: ['0x735faab1c4ec41128c367afb5c3bac73509f70bb'],
-          polygon: ['0x343f2b005cf6d70ba610cd9f1f1927049414b582'],
-        }}
-      />,
-    );
+  it('renders the section heading and description without listing addresses', () => {
+    render(<WhitelistedAddresses />);
 
     expect(screen.getByText('Whitelisted addresses')).toBeInTheDocument();
     expect(
       screen.getByText('Specifies allowed web3 addresses your agent can interact with.'),
     ).toBeInTheDocument();
-    expect(screen.getByText('0x735f...70bb')).toBeInTheDocument();
-    expect(screen.getByText('Chain: gnosis')).toBeInTheDocument();
-    expect(screen.getByText('0x343f...b582')).toBeInTheDocument();
-    expect(screen.getByText('Chain: polygon')).toBeInTheDocument();
-  });
-
-  it('shows the full address on hover via the title attribute', () => {
-    render(
-      <WhitelistedAddresses
-        whitelist={{ gnosis: ['0x735faab1c4ec41128c367afb5c3bac73509f70bb'] }}
-      />,
-    );
-
-    expect(screen.getByTitle('0x735faab1c4ec41128c367afb5c3bac73509f70bb')).toHaveTextContent(
-      '0x735f...70bb',
-    );
+    // The whitelist entries themselves are deliberately not rendered.
+    expect(screen.queryByText(/^0x/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Chain:/)).not.toBeInTheDocument();
   });
 });

--- a/apps/connect-ui/src/App.tsx
+++ b/apps/connect-ui/src/App.tsx
@@ -37,7 +37,7 @@ const Profile = () => {
       {data.protected.mode === 'restricted' && (
         <>
           <Divider style={{ margin: 0 }} />
-          <WhitelistedAddresses whitelist={data.protected.whitelist} />
+          <WhitelistedAddresses />
         </>
       )}
     </>

--- a/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
+++ b/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
@@ -52,7 +52,7 @@ export const PasswordModal = ({
       <Flex vertical gap={12}>
         <Text>{body}</Text>
         <label htmlFor="connect-password">
-          Enter password <Text type="danger">*</Text>
+          Enter your password <Text type="danger">*</Text>
         </label>
         <Input.Password
           id="connect-password"

--- a/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
+++ b/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
@@ -15,9 +15,7 @@ const ConfirmButton = styled(Button)`
     opacity: 0.4;
     color: #ffffff;
     border-color: transparent;
-    background:
-      linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%),
-      #7e22ce;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%), #7e22ce;
     background-blend-mode: overlay, normal;
     box-shadow:
       0 -1px 0 0 rgba(0, 0, 0, 0.05) inset,

--- a/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
+++ b/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
@@ -1,10 +1,32 @@
 import { Alert, Button, Flex, Input, Modal, Typography } from 'antd';
 import { useState } from 'react';
+import styled from 'styled-components';
 
 import { useUpdateSettings } from '../../hooks/useUpdateSettings';
 import { SettingsPatch } from '../../types';
 
 const { Text } = Typography;
+
+// Disabled state per design: brand fill at 40% opacity with inset shadows,
+// instead of antd's washed-out gray.
+const ConfirmButton = styled(Button)`
+  &:disabled {
+    border-radius: 10px;
+    opacity: 0.4;
+    color: #ffffff;
+    border-color: transparent;
+    background:
+      linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%),
+      #7e22ce;
+    background-blend-mode: overlay, normal;
+    box-shadow:
+      0 -1px 0 0 rgba(0, 0, 0, 0.05) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.1) inset,
+      0 -4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 0 0 2px rgba(255, 255, 255, 0.12) inset;
+  }
+`;
 
 type PasswordModalProps = {
   title: string;
@@ -38,7 +60,7 @@ export const PasswordModal = ({
         <Button key="cancel" onClick={onClose}>
           Cancel
         </Button>,
-        <Button
+        <ConfirmButton
           key="confirm"
           type="primary"
           disabled={!password}
@@ -46,7 +68,7 @@ export const PasswordModal = ({
           onClick={handleConfirm}
         >
           {confirmLabel}
-        </Button>,
+        </ConfirmButton>,
       ]}
     >
       <Flex vertical gap={12}>

--- a/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
+++ b/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
@@ -68,8 +68,9 @@ const ModeCard = styled.button<{ $selected: boolean }>`
 
 const RadioDot = styled.span<{ $selected: boolean }>`
   flex: none;
-  width: 16px;
-  height: 16px;
+  box-sizing: border-box;
+  width: 18px;
+  height: 18px;
   margin-top: 2px;
   border-radius: 50%;
   background-color: white;

--- a/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
+++ b/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
@@ -13,7 +13,7 @@ const MODES: { value: Mode; title: string; description: string }[] = [
   {
     value: 'restricted',
     title: 'Restricted',
-    description: 'Agent can only send funds to whitelisted addresses.',
+    description: 'Agent can only interact with whitelisted addresses.',
   },
   {
     value: 'unrestricted',
@@ -25,7 +25,7 @@ const MODES: { value: Mode; title: string; description: string }[] = [
 const MODAL_COPY: Record<Mode, { title: string; body: string; confirm: string }> = {
   unrestricted: {
     title: 'Switch to Unrestricted mode?',
-    body: 'Your agent will be able to send funds to any address. We recommend funding it with only what it needs.',
+    body: 'Your agent will be able to send funds to any address. Consider only funding it with what it needs.',
     confirm: 'Switch to Unrestricted',
   },
   restricted: {

--- a/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
+++ b/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
@@ -1,3 +1,4 @@
+import { InfoCircleOutlined } from '@ant-design/icons';
 import { Alert, Flex, Typography } from 'antd';
 import { useState } from 'react';
 import styled from 'styled-components';
@@ -33,6 +34,23 @@ const MODAL_COPY: Record<Mode, { title: string; body: string; confirm: string }>
     confirm: 'Switch to Restricted',
   },
 };
+
+// Mirrors the Pearl app's blue info alert (.custom-alert--info).
+const UnrestrictedOnAlert = styled(Alert)`
+  padding: 12px;
+  align-items: flex-start;
+  background-color: #ebedff;
+  border-color: #dbe0ff;
+
+  .ant-alert-icon {
+    color: #4d63ff;
+  }
+
+  .ant-alert-message,
+  .ant-alert-description {
+    color: #0016b2;
+  }
+`;
 
 const ModeCard = styled.button<{ $selected: boolean }>`
   flex: 1;
@@ -98,9 +116,10 @@ export const TransactionMode = ({ settings }: TransactionModeProps) => {
           })}
         </Flex>
         {settings.protected.mode === 'unrestricted' && (
-          <Alert
+          <UnrestrictedOnAlert
             type="info"
             showIcon
+            icon={<InfoCircleOutlined />}
             message="Unrestricted mode is on"
             description="Your agent can send funds to any address. Consider only funding it with what it needs."
           />

--- a/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
+++ b/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
@@ -17,7 +17,7 @@ const MODES: { value: Mode; title: string; description: string }[] = [
   {
     value: 'unrestricted',
     title: 'Unrestricted',
-    description: 'Agent can send funds to any recipient address.',
+    description: 'Agent can interact with any recipient address.',
   },
 ];
 
@@ -102,7 +102,7 @@ export const TransactionMode = ({ settings }: TransactionModeProps) => {
             type="info"
             showIcon
             message="Unrestricted mode is on"
-            description="Your agent can send funds to any address. We recommend funding it with only what it needs."
+            description="Your agent can send funds to any address. Consider only funding it with what it needs."
           />
         )}
       </Flex>

--- a/apps/connect-ui/src/components/WhitelistedAddresses/WhitelistedAddresses.tsx
+++ b/apps/connect-ui/src/components/WhitelistedAddresses/WhitelistedAddresses.tsx
@@ -1,36 +1,12 @@
-import { Flex, Typography } from 'antd';
-
-import { Whitelist } from '../../types';
 import { Section } from '../../ui/Section';
 
-const { Text } = Typography;
-
-// The whitelist is BE-owned and read-only, so entries render as-is (address +
-// chain). Friendly names should come from the backend if/when whitelist
-// editing is added — a client-side label map would drift on mech-client
-// upgrades.
-const truncateAddress = (address: string) => `${address.slice(0, 6)}...${address.slice(-4)}`;
-
-type WhitelistedAddressesProps = {
-  whitelist: Whitelist;
-};
-
-export const WhitelistedAddresses = ({ whitelist }: WhitelistedAddressesProps) => (
+// The whitelist itself is BE-owned and deliberately not rendered — the
+// section only explains that restricted mode limits the agent to allowed
+// addresses. Re-introduce a list (with backend-provided friendly names)
+// if/when whitelist editing is added.
+export const WhitelistedAddresses = () => (
   <Section
     title="Whitelisted addresses"
     description="Specifies allowed web3 addresses your agent can interact with."
-  >
-    <Flex vertical gap={16}>
-      {Object.entries(whitelist).flatMap(([chain, addresses]) =>
-        addresses.map((address) => (
-          <Flex key={`${chain}-${address}`} vertical gap={4}>
-            <Text strong title={address}>
-              {truncateAddress(address)}
-            </Text>
-            <Text type="secondary">Chain: {chain}</Text>
-          </Flex>
-        )),
-      )}
-    </Flex>
-  </Section>
+  />
 );

--- a/apps/connect-ui/src/components/WhitelistedAddresses/WhitelistedAddresses.tsx
+++ b/apps/connect-ui/src/components/WhitelistedAddresses/WhitelistedAddresses.tsx
@@ -1,12 +1,31 @@
+import { Flex, Typography } from 'antd';
+
 import { Section } from '../../ui/Section';
 
-// The whitelist itself is BE-owned and deliberately not rendered — the
-// section only explains that restricted mode limits the agent to allowed
-// addresses. Re-introduce a list (with backend-provided friendly names)
-// if/when whitelist editing is added.
+const { Text } = Typography;
+
+// The raw whitelist is BE-owned and deliberately not rendered — instead we
+// describe what the whitelisted addresses refer to. Update this list when the
+// backend whitelist gains new destinations.
+const WHITELISTED_DESTINATIONS = [
+  {
+    name: 'Olas Marketplace',
+    description: 'Connects your agent to the marketplace with various services.',
+  },
+];
+
 export const WhitelistedAddresses = () => (
   <Section
     title="Whitelisted addresses"
     description="Specifies allowed web3 addresses your agent can interact with."
-  />
+  >
+    <Flex vertical gap={16}>
+      {WHITELISTED_DESTINATIONS.map((destination) => (
+        <Flex key={destination.name} vertical gap={4}>
+          <Text strong>{destination.name}</Text>
+          <Text type="secondary">{destination.description}</Text>
+        </Flex>
+      ))}
+    </Flex>
+  </Section>
 );

--- a/apps/connect-ui/src/ui/Section.tsx
+++ b/apps/connect-ui/src/ui/Section.tsx
@@ -10,13 +10,16 @@ const StyledSection = styled.section`
 
 const Description = styled(Text)`
   display: block;
-  margin-bottom: 16px;
+
+  &:not(:last-child) {
+    margin-bottom: 16px;
+  }
 `;
 
 type SectionProps = {
   title: string;
   description: string;
-  children: ReactNode;
+  children?: ReactNode;
 };
 
 export const Section = ({ title, description, children }: SectionProps) => (


### PR DESCRIPTION
## Summary

Copy and design polish for the Connect UI (`apps/connect-ui`) transaction-mode flow.

### Copy
- **Mode cards**: Restricted → "Agent can only interact with whitelisted addresses."; Unrestricted → "Agent can interact with any recipient address."
- **Switch-to-Unrestricted modal**: "Your agent will be able to send funds to any address. Consider only funding it with what it needs."
- **Password label** (both mode-switch directions): "Enter password" → "Enter your password"
- **"Unrestricted mode is on" alert**: "Your agent can send funds to any address. Consider only funding it with what it needs."

### Design
- **Unrestricted-on alert** restyled to match the Pearl app's blue info alert (`.custom-alert--info`): #EBEDFF background, #DBE0FF border, #0016B2 text, outlined #4D63FF icon.
- **Mode-switch confirm button (disabled state)**: brand #7E22CE fill at 0.4 opacity with overlay gradient + inset shadows and 10px radius per design, replacing antd's washed-out gray.
- **Mode radio dots**: fixed at 18×18 with `box-sizing: border-box` — the selected dot previously rendered 26×26 because the 5px border was drawn outside the box.
- **Whitelisted addresses**: raw BE-owned address/chain pairs are no longer listed — the section now describes the whitelisted destinations (e.g. "Olas Marketplace — Connects your agent to the marketplace with various services."). `Section`'s `children` is now optional.

### Tests
- Password-label queries updated; whitelist specs now assert entries are *not* rendered.
- `npx nx test connect-ui` — 31/31 pass; `npx nx lint connect-ui` clean.

## Screenshots

**Mode cards (restricted selected)**

<img src="https://raw.githubusercontent.com/valory-xyz/olas-operate-app/screenshots/vlop-101/1-mode-cards.png" width="640" />

**Switch-to-Unrestricted password modal (disabled confirm state)**

<img src="https://raw.githubusercontent.com/valory-xyz/olas-operate-app/screenshots/vlop-101/2-password-modal.png" width="640" />

**Unrestricted mode on**

<img src="https://raw.githubusercontent.com/valory-xyz/olas-operate-app/screenshots/vlop-101/3-unrestricted-alert.png" width="640" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
