### PR TITLE
style(connect-ui): align Profile UI with Figma

### DIFF
--- a/apps/connect-ui/src/App.tsx
+++ b/apps/connect-ui/src/App.tsx
@@ -7,13 +7,15 @@ import { CodingTool } from './components/CodingTool/CodingTool';
 import { GetStarted } from './components/GetStarted/GetStarted';
 import { TransactionMode } from './components/TransactionMode/TransactionMode';
 import { WhitelistedAddresses } from './components/WhitelistedAddresses/WhitelistedAddresses';
+import { COLOR } from './constants/theme';
 import { useSettings } from './hooks/useSettings';
+import { GlobalStyles as ConnectGlobalStyles } from './ui/GlobalStyles';
 
 const Panel = styled.div`
   flex: 1;
   background-color: white;
-  border-left: 1px solid #e4e4e4;
-  border-right: 1px solid #e4e4e4;
+  border-left: 1px solid ${COLOR.BORDER};
+  border-right: 1px solid ${COLOR.BORDER};
 `;
 
 const Profile = () => {
@@ -54,6 +56,7 @@ const App = () => {
           </Panel>
         </Flex>
         <GlobalStyles />
+        <ConnectGlobalStyles />
       </AntdApp>
     </ErrorBoundary>
   );

--- a/apps/connect-ui/src/components/CodingTool/CodingTool.tsx
+++ b/apps/connect-ui/src/components/CodingTool/CodingTool.tsx
@@ -1,5 +1,7 @@
 import { Select } from 'antd';
+import styled from 'styled-components';
 
+import { COLOR } from '../../constants/theme';
 import { useUpdateSettings } from '../../hooks/useUpdateSettings';
 import { ConnectSettings, Harness } from '../../types';
 import { Section } from '../../ui/Section';
@@ -8,6 +10,31 @@ const HARNESS_OPTIONS: { value: Harness; label: string }[] = [
   { value: 'claude_code_desktop', label: 'Claude Desktop' },
   { value: 'claude_code_cli', label: 'Claude Code CLI' },
 ];
+
+// Filled, rounded gray control per Figma — no border, subtle gray fill that
+// darkens on hover, 36px tall (Select `controlHeight` token in theme.ts).
+const StyledSelect = styled(Select<Harness>)`
+  width: max-content;
+
+  .ant-select-selector {
+    border-radius: 10px !important;
+    background-color: ${COLOR.SELECT_BG} !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
+  }
+
+  .ant-select-selection-item {
+    font-size: 14px;
+  }
+
+  &:hover .ant-select-selector {
+    background-color: ${COLOR.SELECT_BG_HOVER} !important;
+  }
+
+  .ant-select-arrow {
+    color: ${COLOR.SELECT_ARROW};
+  }
+`;
 
 type CodingToolProps = {
   settings: ConnectSettings;
@@ -20,13 +47,14 @@ export const CodingTool = ({ settings }: CodingToolProps) => {
 
   return (
     <Section title="Coding tool" description="Choose where you run your Connect agent.">
-      <Select<Harness>
+      <StyledSelect
         variant="filled"
         value={settings.harness}
         options={HARNESS_OPTIONS}
         loading={isPending}
         onChange={(value) => mutate({ harness: value })}
         popupMatchSelectWidth={false}
+        popupClassName="connect-harness-popup"
       />
     </Section>
   );

--- a/apps/connect-ui/src/components/GetStarted/GetStarted.tsx
+++ b/apps/connect-ui/src/components/GetStarted/GetStarted.tsx
@@ -22,7 +22,12 @@ export const GetStarted = () => {
       description="Work with your Connect agent from your coding tool."
     >
       <Flex vertical align="flex-start" gap={12}>
-        <Button icon={<GradientDot />} loading={isPending} onClick={() => mutate()}>
+        <Button
+          icon={<GradientDot />}
+          loading={isPending}
+          onClick={() => mutate()}
+          style={{ fontSize: 14, width: 204 }}
+        >
           New Connect Session
         </Button>
         {error && <Alert type="error" showIcon closable onClose={reset} message={error.message} />}

--- a/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
+++ b/apps/connect-ui/src/components/PasswordModal/PasswordModal.tsx
@@ -2,10 +2,84 @@ import { Alert, Button, Flex, Input, Modal, Typography } from 'antd';
 import { useState } from 'react';
 import styled from 'styled-components';
 
+import { COLOR } from '../../constants/theme';
 import { useUpdateSettings } from '../../hooks/useUpdateSettings';
 import { SettingsPatch } from '../../types';
 
 const { Text } = Typography;
+
+// Modal chrome per Figma: 464px wide, 24px padding, 12px (Spacing/md) radius,
+// 3px translucent-white border, 20px/500/28px title, black close icon, and a
+// 12px gap between the footer buttons.
+const StyledModal = styled(Modal)`
+  .ant-modal-content {
+    padding: 24px;
+    border-radius: 12px;
+    border: 3px solid rgba(255, 255, 255, 0.25);
+  }
+
+  .ant-modal-header {
+    margin-bottom: 24px;
+  }
+
+  .ant-modal-title {
+    font-weight: 500;
+    font-size: 20px;
+    line-height: 28px;
+    color: ${COLOR.TEXT_TITLE};
+  }
+
+  .ant-modal-close {
+    top: 24px;
+    inset-inline-end: 24px;
+    color: ${COLOR.BLACK};
+  }
+
+  .ant-modal-close-icon {
+    color: ${COLOR.BLACK};
+  }
+
+  .ant-modal-body {
+    margin-bottom: 24px;
+  }
+
+  .ant-modal-footer {
+    margin-top: 0;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  .ant-modal-footer > .ant-btn + .ant-btn {
+    margin-inline-start: 0;
+  }
+`;
+
+// Explanatory body copy — 16px / 400 / 24px, rgba(54, 63, 73, 1).
+const BodyText = styled.p`
+  margin: 0;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 24px;
+  color: ${COLOR.TEXT_SECONDARY};
+`;
+
+// Field label — 14px tertiary, matching Pearl's password fields.
+const PasswordLabel = styled.label`
+  font-size: 14px;
+  line-height: 20px;
+  color: ${COLOR.TEXT_TERTIARY};
+`;
+
+// Password field styled like Pearl's (olas-operate-app): small size, 6px 12px
+// padding, 16px text.
+const PasswordField = styled(Input.Password)`
+  padding: 6px 12px;
+
+  input.ant-input {
+    font-size: 16px;
+  }
+`;
 
 // Disabled state per design: brand fill at 40% opacity with inset shadows,
 // instead of antd's washed-out gray.
@@ -13,9 +87,10 @@ const ConfirmButton = styled(Button)`
   &:disabled {
     border-radius: 10px;
     opacity: 0.4;
-    color: #ffffff;
+    color: ${COLOR.WHITE};
     border-color: transparent;
-    background: linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%), #7e22ce;
+    background:
+      linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%), ${COLOR.PRIMARY};
     background-blend-mode: overlay, normal;
     box-shadow:
       0 -1px 0 0 rgba(0, 0, 0, 0.05) inset,
@@ -50,10 +125,12 @@ export const PasswordModal = ({
   };
 
   return (
-    <Modal
+    <StyledModal
       open
+      width={464}
       title={title}
       onCancel={onClose}
+      styles={{ mask: { backgroundColor: COLOR.MASK } }}
       footer={[
         <Button key="cancel" onClick={onClose}>
           Cancel
@@ -69,18 +146,22 @@ export const PasswordModal = ({
         </ConfirmButton>,
       ]}
     >
-      <Flex vertical gap={12}>
-        <Text>{body}</Text>
-        <label htmlFor="connect-password">
-          Enter your password <Text type="danger">*</Text>
-        </label>
-        <Input.Password
-          id="connect-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
+      <Flex vertical gap={24}>
+        <BodyText>{body}</BodyText>
+        <Flex vertical gap={4}>
+          <PasswordLabel htmlFor="connect-password">
+            Enter your password <Text type="danger">*</Text>
+          </PasswordLabel>
+          <PasswordField
+            id="connect-password"
+            size="small"
+            placeholder="Enter your password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </Flex>
         {error && <Alert type="error" showIcon message={error.message} />}
       </Flex>
-    </Modal>
+    </StyledModal>
   );
 };

--- a/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
+++ b/apps/connect-ui/src/components/TransactionMode/TransactionMode.tsx
@@ -1,13 +1,12 @@
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { Alert, Flex, Typography } from 'antd';
+import { Alert, Flex } from 'antd';
 import { useState } from 'react';
 import styled from 'styled-components';
 
+import { COLOR } from '../../constants/theme';
 import { ConnectSettings, TransactionMode as Mode } from '../../types';
 import { Section } from '../../ui/Section';
 import { PasswordModal } from '../PasswordModal/PasswordModal';
-
-const { Text } = Typography;
 
 const MODES: { value: Mode; title: string; description: string }[] = [
   {
@@ -39,16 +38,27 @@ const MODAL_COPY: Record<Mode, { title: string; body: string; confirm: string }>
 const UnrestrictedOnAlert = styled(Alert)`
   padding: 12px;
   align-items: flex-start;
-  background-color: #ebedff;
-  border-color: #dbe0ff;
+  background-color: ${COLOR.INFO_BG};
+  border: 1px solid ${COLOR.INFO_BORDER};
 
   .ant-alert-icon {
-    color: #4d63ff;
+    font-size: 20px;
+    color: ${COLOR.INFO_ICON};
   }
 
-  .ant-alert-message,
+  .ant-alert-message {
+    margin-bottom: 4px;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 20px;
+    color: ${COLOR.INFO_TEXT};
+  }
+
   .ant-alert-description {
-    color: #0016b2;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+    color: ${COLOR.INFO_TEXT};
   }
 `;
 
@@ -62,8 +72,8 @@ const ModeCard = styled.button<{ $selected: boolean }>`
   border-radius: 10px;
   cursor: pointer;
   font: inherit;
-  border: 1px solid ${({ $selected }) => ($selected ? '#D3ADF7' : '#E4E4E4')};
-  background-color: ${({ $selected }) => ($selected ? '#F9F0FF' : 'transparent')};
+  border: 1px solid ${({ $selected }) => ($selected ? COLOR.MODE_SELECTED_BORDER : COLOR.BORDER)};
+  background-color: ${({ $selected }) => ($selected ? COLOR.MODE_SELECTED_BG : 'transparent')};
 `;
 
 const RadioDot = styled.span<{ $selected: boolean }>`
@@ -74,7 +84,24 @@ const RadioDot = styled.span<{ $selected: boolean }>`
   margin-top: 2px;
   border-radius: 50%;
   background-color: white;
-  border: ${({ $selected }) => ($selected ? '5px solid #7E22CE' : '1px solid #D9D9D9')};
+  border: ${({ $selected }) =>
+    $selected ? `5px solid ${COLOR.PRIMARY}` : `1px solid ${COLOR.RADIO_BORDER}`};
+`;
+
+// Card title — 14px / 500 / 20px (no <strong>, per design).
+const ModeTitle = styled.span`
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 20px;
+  color: ${COLOR.TEXT_PRIMARY};
+`;
+
+// Card hint — 14px / 400 / 20px, rgba(97, 112, 132, 1).
+const ModeDescription = styled.span`
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: ${COLOR.TEXT_TERTIARY};
 `;
 
 type TransactionModeProps = {
@@ -109,8 +136,8 @@ export const TransactionMode = ({ settings }: TransactionModeProps) => {
               >
                 <RadioDot $selected={isSelected} />
                 <Flex vertical gap={4}>
-                  <Text strong>{mode.title}</Text>
-                  <Text type="secondary">{mode.description}</Text>
+                  <ModeTitle>{mode.title}</ModeTitle>
+                  <ModeDescription>{mode.description}</ModeDescription>
                 </Flex>
               </ModeCard>
             );

--- a/apps/connect-ui/src/components/WhitelistedAddresses/WhitelistedAddresses.tsx
+++ b/apps/connect-ui/src/components/WhitelistedAddresses/WhitelistedAddresses.tsx
@@ -1,8 +1,24 @@
-import { Flex, Typography } from 'antd';
+import { Flex } from 'antd';
+import styled from 'styled-components';
 
+import { COLOR } from '../../constants/theme';
 import { Section } from '../../ui/Section';
 
-const { Text } = Typography;
+// Destination name — 14px, medium weight (no <strong>, per design).
+const DestinationName = styled.span`
+  font-weight: 450;
+  font-size: 14px;
+  line-height: 20px;
+  color: ${COLOR.TEXT_PRIMARY};
+`;
+
+// Destination hint — 12px, rgba(97, 112, 132, 1).
+const DestinationDescription = styled.span`
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 18px;
+  color: ${COLOR.TEXT_TERTIARY};
+`;
 
 // The raw whitelist is BE-owned and deliberately not rendered — instead we
 // describe what the whitelisted addresses refer to. Update this list when the
@@ -22,8 +38,8 @@ export const WhitelistedAddresses = () => (
     <Flex vertical gap={16}>
       {WHITELISTED_DESTINATIONS.map((destination) => (
         <Flex key={destination.name} vertical gap={4}>
-          <Text strong>{destination.name}</Text>
-          <Text type="secondary">{destination.description}</Text>
+          <DestinationName>{destination.name}</DestinationName>
+          <DestinationDescription>{destination.description}</DestinationDescription>
         </Flex>
       ))}
     </Flex>

--- a/apps/connect-ui/src/constants/theme.ts
+++ b/apps/connect-ui/src/constants/theme.ts
@@ -1,17 +1,59 @@
 import { ThemeConfig } from 'antd';
 
 /**
- * Mirrors Pearl's design tokens (olas-operate-app
- * frontend/constants/theme/theme.ts + constants/colors.ts) — this Profile tab
- * renders inside Pearl's iframe, so buttons/inputs must match the host.
+ * Shared color tokens for connect-ui. Mirrors Pearl's design tokens
+ * (olas-operate-app frontend/constants/colors.ts) — this Profile tab renders
+ * inside Pearl's iframe, so buttons/inputs must match the host. Import `COLOR`
+ * in styled-components instead of repeating hex values.
  */
+export const COLOR = {
+  // Brand
+  PRIMARY: '#7E22CE',
+  PRIMARY_HOVER: '#6A1CB1',
+  PRIMARY_ACTIVE: '#5C1A9E',
+  PRIMARY_DARK: '#36075F',
+
+  WHITE: '#FFFFFF',
+  BLACK: '#000000',
+
+  // Text
+  TEXT_PRIMARY: '#0F172A',
+  TEXT_SECONDARY: '#363F49',
+  TEXT_TERTIARY: '#617084',
+  TEXT_TITLE: '#1F2229',
+
+  // Borders & fills
+  BORDER: '#DFE6EC',
+  BORDER_LIGHT: '#EAEDF1',
+  FILL_SECONDARY: '#E4E4E4',
+
+  // Coding-tool select
+  SELECT_BG: '#F2F4F9',
+  SELECT_BG_HOVER: '#EDF2F7',
+  SELECT_ARROW: '#4D596A',
+
+  // Transaction-mode radio cards
+  MODE_SELECTED_BORDER: '#ECDCF9',
+  MODE_SELECTED_BG: '#F5EDFC',
+  RADIO_BORDER: '#D9D9D9',
+
+  // Info alert ("Unrestricted mode is on")
+  INFO_BG: '#EBEDFF',
+  INFO_BORDER: '#DBE0FF',
+  INFO_ICON: '#4D63FF',
+  INFO_TEXT: '#0016B2',
+
+  // Modal backdrop
+  MASK: 'rgba(15, 22, 36, 0.2)',
+} as const;
+
 export const mainTheme: ThemeConfig = {
   token: {
-    colorPrimary: '#7E22CE',
-    colorLink: '#7E22CE',
-    colorText: '#0F172A',
-    colorTextSecondary: '#363F49',
-    colorFillSecondary: '#E4E4E4',
+    colorPrimary: COLOR.PRIMARY,
+    colorLink: COLOR.PRIMARY,
+    colorText: COLOR.TEXT_PRIMARY,
+    colorTextSecondary: COLOR.TEXT_SECONDARY,
+    colorFillSecondary: COLOR.FILL_SECONDARY,
     fontSize: 16,
     fontFamily: 'Inter',
     fontWeightStrong: 500,
@@ -22,30 +64,41 @@ export const mainTheme: ThemeConfig = {
       fontSizeIcon: 16,
     },
     Button: {
+      controlHeight: 36,
+      borderRadius: 10,
       fontSize: 16,
       fontSizeLG: 16,
       // For "primary" buttons
-      colorPrimary: '#7e22ce',
-      colorPrimaryHover: '#6a1cb1',
-      colorPrimaryActive: '#5c1a9e',
-      colorTextLightSolid: '#ffffff',
-      colorTextDisabled: '#ffffff',
+      colorPrimary: COLOR.PRIMARY,
+      colorPrimaryHover: COLOR.PRIMARY_HOVER,
+      colorPrimaryActive: COLOR.PRIMARY_ACTIVE,
+      colorTextLightSolid: COLOR.WHITE,
+      colorTextDisabled: COLOR.WHITE,
       // For "default" buttons
-      colorText: '#000000',
-      colorBorder: '#dfe6ec',
+      colorText: COLOR.BLACK,
+      colorBorder: COLOR.BORDER,
+    },
+    Divider: {
+      // Section separators — 1px, rgba(223, 230, 236, 1)
+      colorSplit: COLOR.BORDER,
+    },
+    Select: {
+      controlHeight: 36,
+      borderRadius: 10,
+      fontSize: 16,
     },
     Card: {
       padding: 20,
       fontWeightStrong: 400,
       borderRadiusLG: 10,
-      colorBorderSecondary: '#E4E4E4',
+      colorBorderSecondary: COLOR.FILL_SECONDARY,
     },
     Input: {
       fontSize: 16,
       paddingBlock: 8,
       paddingInline: 8,
-      colorBorder: '#EAEDF1',
-      hoverBorderColor: '#DFE6EC',
+      colorBorder: COLOR.BORDER_LIGHT,
+      hoverBorderColor: COLOR.BORDER,
     },
   },
 } as const;

--- a/apps/connect-ui/src/ui/GlobalStyles.tsx
+++ b/apps/connect-ui/src/ui/GlobalStyles.tsx
@@ -1,0 +1,124 @@
+import { createGlobalStyle } from 'styled-components';
+
+/**
+ * Button redesigns ported verbatim from Pearl
+ * (olas-operate-app frontend/styles/globals.scss) — this Profile tab renders
+ * inside Pearl's iframe, so buttons must match the host: soft inset shadows,
+ * gradient primary fill, 36px height (set via the Button `controlHeight` token
+ * in constants/theme.ts).
+ */
+export const GlobalStyles = createGlobalStyle`
+  /* === Primary buttons === */
+  .ant-btn-primary {
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%), #7e22ce;
+    background-blend-mode: overlay, normal;
+    box-shadow:
+      0 -1px 0 0 rgba(0, 0, 0, 0.05) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.1) inset,
+      0 -4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 0 0 2px rgba(255, 255, 255, 0.12) inset;
+  }
+
+  .ant-btn-primary:hover {
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.3) 100%), #7e22ce;
+    background-blend-mode: overlay, normal;
+    box-shadow:
+      0 -1px 0 0 rgba(0, 0, 0, 0.05) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.1) inset,
+      0 -4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 0 0 2px rgba(255, 255, 255, 0.06) inset;
+  }
+
+  .ant-btn-primary:focus-visible,
+  .ant-btn-primary:active {
+    background:
+      linear-gradient(180deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.1) 100%),
+      linear-gradient(0deg, rgba(0, 0, 0, 0.3) 0%, rgba(0, 0, 0, 0.3) 100%),
+      #7e22ce;
+    background-blend-mode: normal, overlay, normal;
+    box-shadow:
+      0 -1px 0 0 rgba(0, 0, 0, 0.5) inset,
+      0 1.5px 0.5px 0.5px rgba(0, 0, 0, 0.15) inset;
+  }
+
+  .ant-btn-primary:disabled {
+    opacity: 0.4;
+    background: linear-gradient(0deg, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.1) 100%), #7e22ce;
+    background-blend-mode: overlay, normal;
+    box-shadow:
+      0 -1px 0 0 rgba(0, 0, 0, 0.05) inset,
+      0 0 0 1px rgba(0, 0, 0, 0.1) inset,
+      0 -4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 4px 16px 0 rgba(255, 255, 255, 0.24) inset,
+      0 0 0 2px rgba(255, 255, 255, 0.12) inset;
+  }
+
+  /* === Default buttons === */
+  .ant-btn-default {
+    background: #fff;
+    box-shadow:
+      0 -1px 0 0 #dfe6ec inset,
+      0 0 0 1px #eaedf1 inset,
+      0 0 0 2px #fff inset,
+      0 4px 8px 0 rgba(255, 255, 255, 0.5) inset,
+      0 0 8px 2px #edf2f7 inset;
+    border: 1px transparent;
+    transition: background 0.2s ease, box-shadow 0.1s ease;
+  }
+
+  .ant-btn-default:not(:disabled):not(.ant-btn-disabled):hover {
+    border: 1px transparent;
+    color: #000000 !important;
+    background: #edf2f7;
+    box-shadow:
+      0 -1px 0 0 #d1d9e6 inset,
+      0 0 0 1px #dfe6ec inset,
+      0 0 0 2px rgba(255, 255, 255, 0.5) inset;
+  }
+
+  .ant-btn-default:not(:disabled):not(.ant-btn-disabled):focus-visible,
+  .ant-btn-default:not(:disabled):not(.ant-btn-disabled):active {
+    background: #dfe6ec !important;
+    box-shadow:
+      0 -1px 0 0 rgba(0, 0, 0, 0.1) inset,
+      0 1.25px 0.5px 1px rgba(0, 0, 0, 0.1) inset;
+  }
+
+  .ant-btn-default:disabled {
+    border: 1px solid #dfe6ec;
+    color: #000000 !important;
+    opacity: 0.4;
+    background: #fff;
+    box-shadow:
+      0 -1px 0 0 #dfe6ec inset,
+      0 0 0 1px #eaedf1 inset,
+      0 0 0 2px #fff inset,
+      0 0 0 3px #f4f7fa inset,
+      0 4px 8px 0 rgba(255, 255, 255, 0.5) inset,
+      0 0 6px 2px #edf2f7 inset;
+  }
+
+  /* === Link buttons === */
+  .ant-btn-link {
+    color: #7e22ce !important;
+  }
+
+  .ant-btn-link:hover,
+  .ant-btn-link:focus-visible,
+  .ant-btn-link:active {
+    color: #36075f !important;
+  }
+
+  .ant-btn-link:disabled,
+  .ant-btn-text:disabled {
+    opacity: 0.4;
+    color: #000000 !important;
+  }
+
+  /* === Coding-tool select dropdown (rendered in a portal) === */
+  .connect-harness-popup .ant-select-item-option-content {
+    font-size: 14px;
+  }
+`;

--- a/apps/connect-ui/src/ui/Section.tsx
+++ b/apps/connect-ui/src/ui/Section.tsx
@@ -1,15 +1,28 @@
-import { Typography } from 'antd';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 
-const { Text, Title } = Typography;
+import { COLOR } from '../constants/theme';
 
 const StyledSection = styled.section`
   padding: 24px 28px;
 `;
 
-const Description = styled(Text)`
-  display: block;
+// Section title — 16px / 450 / 24px, primary text color.
+const Title = styled.h2`
+  margin: 0 0 4px;
+  font-weight: 450;
+  font-size: 16px;
+  line-height: 24px;
+  color: ${COLOR.TEXT_PRIMARY};
+`;
+
+// Hint below the title — 14px / 400 / 20px, rgba(97, 112, 132, 1).
+const Description = styled.p`
+  margin: 0;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: ${COLOR.TEXT_TERTIARY};
 
   &:not(:last-child) {
     margin-bottom: 16px;
@@ -24,10 +37,8 @@ type SectionProps = {
 
 export const Section = ({ title, description, children }: SectionProps) => (
   <StyledSection>
-    <Title level={5} style={{ marginTop: 0, marginBottom: 4 }}>
-      {title}
-    </Title>
-    <Description type="secondary">{description}</Description>
+    <Title>{title}</Title>
+    <Description>{description}</Description>
     {children}
   </StyledSection>
 );


### PR DESCRIPTION
## Summary

Aligns the connect-ui Profile tab with the Figma design and Pearl's (olas-operate-app) host styling. Styling-only — no behavior changes.

### Buttons
- Ports Pearl's soft inset-shadow button redesign (primary / default / link, all states) into a new `src/ui/GlobalStyles.tsx` (verbatim from olas `styles/globals.scss`).
- 36px height + 10px radius via `Button` theme tokens.
- "New Connect Session" pinned to **204px** width, **14px** label.

### Typography & layout
- Section titles → **16px / 450 / 24px**; hints → **14px / 400 / 20px** in `#617084`.
- Section separators + panel borders unified to `#DFE6EC`.
- Removed all `<strong>` tags — weight applied via `font-weight`.

### Components
- **Coding-tool select**: filled gray, rounded, `max-content` width, 14px text + options.
- **Transaction-mode radio cards**: selected border `#ECDCF9` / bg `#F5EDFC`, 14px/500 titles, 14px/400 hints.
- **"Unrestricted mode is on" alert**: `#EBEDFF` bg, `#DBE0FF` border, 20px `#4D63FF` icon, `#0016B2` text, 4px title/text gap.
- **Switch-mode modal**: 464px wide, 24px padding, 12px radius, 3px translucent-white border, 20px `#1F2229` title, black close icon, Pearl-style password field, 12px footer gap, `rgba(15,22,36,0.2)` mask.

### Refactor
- Centralizes every color in a shared `COLOR` const in `constants/theme.ts`, matching the `agentsfun-ui` / `predict-ui` pattern. `GlobalStyles.tsx` intentionally left with literals to stay a 1:1 mirror of olas `globals.scss`.

## Screenshots
<img width="777" height="724" alt="Screenshot 2026-07-22 at 13 01 09" src="https://github.com/user-attachments/assets/b6ec38dd-5653-4c14-b17e-f644a6278003" />

<img width="775" height="729" alt="Screenshot 2026-07-22 at 13 01 15" src="https://github.com/user-attachments/assets/c9b06e46-9b6e-4630-8b8b-74b3d891fc7c" />

<img width="777" height="392" alt="Screenshot 2026-07-22 at 13 01 26" src="https://github.com/user-attachments/assets/0c6d1d1d-8682-45bb-b3d3-8e82b0c56b92" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)